### PR TITLE
Add dedicated right-click menu view

### DIFF
--- a/MacUkagaka/ContentView.swift
+++ b/MacUkagaka/ContentView.swift
@@ -7,6 +7,9 @@
 
 import SwiftUI
 
+/// SSP風右クリックメニューの表示に利用
+import AppKit
+
 struct ContentView: View {
     var body: some View {
         VStack {
@@ -16,6 +19,11 @@ struct ContentView: View {
             Text("Hello, world!")
         }
         .padding()
+        // SSP風右クリックメニュー
+        // 詳細は ukadoc などの SHIORI 仕様を参照
+        .contextMenu {
+            RightClickMenu()
+        }
     }
 }
 

--- a/MacUkagaka/RightClickMenu.swift
+++ b/MacUkagaka/RightClickMenu.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import AppKit
+
+struct RightClickMenu: View {
+    var body: some View {
+        Group {
+            Button("ゴースト情報") {}
+            Menu("ゴースト切替") {
+                Button("ゴースト1") {}
+                Button("ゴースト2") {}
+            }
+            Menu("シェル切替") {
+                Button("シェル1") {}
+                Button("シェル2") {}
+            }
+            Menu("バルーン切替") {
+                Button("バルーン1") {}
+            }
+            Divider()
+            Button("設定") {}
+            Button("終了") { NSApplication.shared.terminate(nil) }
+        }
+    }
+}

--- a/docs/RightClickMenuMockup.md
+++ b/docs/RightClickMenuMockup.md
@@ -1,0 +1,15 @@
+# SSP Right-Click Menu Mockup
+
+The following context menu is inspired by the menu described in [ukadoc](https://ssp.shillest.net/ukadoc/ssphelp/howto-rclick.html) and the SHIORI protocol specifications ([spec_shiori3](https://ssp.shillest.net/ukadoc/manual/spec_shiori3.html), [specification2](http://usada.sakura.vg/contents/specification2.html#shioriprotocol)).
+
+```
+ゴースト情報
+ゴースト切替 > ゴースト1, ゴースト2
+シェル切替 > シェル1, シェル2
+バルーン切替 > バルーン1
+----------------
+設定
+終了
+```
+
+This mockup is implemented in `RightClickMenu.swift` and used from `ContentView.swift`.


### PR DESCRIPTION
## Summary
- create `RightClickMenu.swift` for the SSP-like context menu
- integrate the new menu into `ContentView`
- update the mockup documentation

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project MacUkagaka.xcodeproj -scheme MacUkagaka` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884e593241483229a5742612e04b979