### PR TITLE
Add ephemeral shared memory unlink

### DIFF
--- a/"b/docs/\346\227\245\346\234\254\350\252\236\343\203\211\343\202\255\343\203\245\343\203\241\343\203\263\343\203\210.md"
+++ b/"b/docs/\346\227\245\346\234\254\350\252\236\343\203\211\343\202\255\343\203\245\343\203\241\343\203\263\343\203\210.md"
@@ -1,0 +1,28 @@
+# FMO機能について
+
+このドキュメントでは、Windows向けゲームやゴーストで利用されているFMO(Forged Memory Object)をmacOS上で再現するための実装方針を説明します。
+
+## 目的
+- 名前付き共有メモリを用いてプロセス間で64KBのデータ領域を共有する
+- 名前付きセマフォを利用して排他制御を行う
+- 起動判定としてセマフォが既に存在するかどうかを確認する
+
+## 主要クラス
+- `FmoMutex`
+  - 名前付きセマフォをラップしたMutexクラス
+  - `lock()` と `unlock()` で排他制御を行います
+- `FmoSharedMemory`
+  - POSIX共有メモリをSwiftから扱うためのラッパー
+  - `shm_open` 後に `shm_unlink` を行い、最後のクローズで自動削除されるエフェメラル運用を採用
+  - 先頭4バイトにデータサイズ、末尾にNUL終端を書き込みます
+- `FmoManager`
+  - 上記2つをまとめて初期化し、アプリケーション起動時に使用します
+
+## 使用例
+```swift
+let manager = try FmoManager()
+try manager.memory.write(data, mutex: manager.mutex)
+let received = try manager.memory.read(mutex: manager.mutex)
+```
+
+アプリケーション終了時には `cleanup()` を呼び、共有メモリとセマフォを解放します。

--- a/MacUkagaka/FMO/FmoBridge.c
+++ b/MacUkagaka/FMO/FmoBridge.c
@@ -1,0 +1,79 @@
+/*
+ * POSIX 共有メモリとセマフォを扱うブリッジ実装
+ */
+#include "FmoBridge.h"
+
+/* 名前付き共有メモリを開き、指定サイズに拡張する */
+/*
+ * 名前付き共有メモリを開き、指定サイズに拡張する。
+ * Windows の FMO に近づけるため、生成後すぐに unlink して
+ * クラッシュ時に残骸が残らないようにする。
+ */
+int fmo_open_shared(const char *name, size_t size) {
+    int fd = shm_open(name, O_CREAT | O_RDWR, 0666);
+    if (fd == -1) {
+        return -1;
+    }
+    if (ftruncate(fd, size) == -1) {
+        close(fd);
+        return -1;
+    }
+    /* エフェメラル運用のため直後に名前を削除 */
+    shm_unlink(name);
+    return fd;
+}
+
+/* 共有メモリをマップする */
+void *fmo_map(int fd, size_t size) {
+    return mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+}
+
+/* ftruncate の薄いラッパー */
+int fmo_ftruncate(int fd, size_t size) {
+    return ftruncate(fd, size);
+}
+
+/* fd をクローズする */
+int fmo_close_fd(int fd) {
+    return close(fd);
+}
+
+/* 名前付き共有メモリを削除する */
+int fmo_shm_unlink(const char *name) {
+    return shm_unlink(name);
+}
+
+/* マッピングを解除する */
+int fmo_munmap(void *addr, size_t size) {
+    return munmap(addr, size);
+}
+
+/* 名前付きセマフォを開く */
+sem_t *fmo_sem_open(const char *name, int oflag, mode_t mode, unsigned int value) {
+    return sem_open(name, oflag, mode, value);
+}
+
+/* セマフォ待機 */
+int fmo_sem_wait(sem_t *sem) {
+    return sem_wait(sem);
+}
+
+/* セマフォをノンブロッキングで取得 */
+int fmo_sem_trywait(sem_t *sem) {
+    return sem_trywait(sem);
+}
+
+/* セマフォ解放 */
+int fmo_sem_post(sem_t *sem) {
+    return sem_post(sem);
+}
+
+/* セマフォをクローズ */
+int fmo_sem_close(sem_t *sem) {
+    return sem_close(sem);
+}
+
+/* セマフォを削除 */
+int fmo_sem_unlink(const char *name) {
+    return sem_unlink(name);
+}

--- a/MacUkagaka/FMO/FmoBridge.h
+++ b/MacUkagaka/FMO/FmoBridge.h
@@ -1,0 +1,30 @@
+#ifndef FMO_BRIDGE_H
+#define FMO_BRIDGE_H
+/*
+ * POSIX の共有メモリとセマフォを Swift から利用するための
+ * シンプルな C ラッパー関数群です。各関数は対応する libc
+ * 関数をそのまま呼び出します。
+ */
+#include <semaphore.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdint.h>
+
+int fmo_open_shared(const char *name, size_t size);
+void *fmo_map(int fd, size_t size);
+int fmo_ftruncate(int fd, size_t size);
+int fmo_close_fd(int fd);
+int fmo_shm_unlink(const char *name);
+int fmo_munmap(void *addr, size_t size);
+
+/* セマフォ操作用ラッパー */
+sem_t *fmo_sem_open(const char *name, int oflag, mode_t mode, unsigned int value);
+int fmo_sem_wait(sem_t *sem);
+int fmo_sem_trywait(sem_t *sem);
+int fmo_sem_post(sem_t *sem);
+int fmo_sem_close(sem_t *sem);
+int fmo_sem_unlink(const char *name);
+
+#endif

--- a/MacUkagaka/FMO/FmoError.swift
+++ b/MacUkagaka/FMO/FmoError.swift
@@ -1,0 +1,7 @@
+// FMO 操作で発生し得るエラーを表す列挙型
+import Foundation
+
+enum FmoError: Error {
+    case alreadyRunning
+    case systemError(String)
+}

--- a/MacUkagaka/FMO/FmoManager.swift
+++ b/MacUkagaka/FMO/FmoManager.swift
@@ -1,0 +1,19 @@
+// FMO全体の初期化と後始末をまとめる管理クラス
+import Foundation
+
+final class FmoManager {
+    let mutex: FmoMutex
+    let memory: FmoSharedMemory
+
+    /// 共有メモリとセマフォを初期化する
+    init(mutexName: String = "/ssp_mutex", sharedName: String = "/ssp_fmo") throws {
+        mutex = try FmoMutex(name: mutexName)
+        memory = try FmoSharedMemory(name: sharedName)
+    }
+
+    /// 使用したリソースを解放する
+    func cleanup() {
+        memory.close()
+        mutex.close()
+    }
+}

--- a/MacUkagaka/FMO/FmoMutex.swift
+++ b/MacUkagaka/FMO/FmoMutex.swift
@@ -1,0 +1,45 @@
+// POSIX名前付きセマフォをSwiftオブジェクトとして扱うクラス
+import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+final class FmoMutex {
+    private let name: String
+    private var sem: OpaquePointer?
+
+    init(name: String) throws {
+        self.name = name
+        sem = fmo_sem_open(name, O_CREAT | O_EXCL, 0o666, 1)
+        if sem == nil {
+            if errno == EEXIST {
+                throw FmoError.alreadyRunning
+            } else {
+                throw FmoError.systemError(String(cString: strerror(errno)))
+            }
+        }
+    }
+
+    /// セマフォを獲得する。失敗時は例外を投げる。
+    func lock() throws {
+        if fmo_sem_wait(sem) == -1 {
+            throw FmoError.systemError("sem_wait failed")
+        }
+    }
+
+    /// セマフォを解放する。
+    func unlock() {
+        _ = fmo_sem_post(sem)
+    }
+
+    /// セマフォをクローズし、名前付きセマフォを削除する。
+    func close() {
+        if let s = sem {
+            fmo_sem_close(s)
+            fmo_sem_unlink(name)
+            sem = nil
+        }
+    }
+}

--- a/MacUkagaka/FMO/FmoSharedMemory.swift
+++ b/MacUkagaka/FMO/FmoSharedMemory.swift
@@ -1,0 +1,61 @@
+// 共有メモリ領域を扱うSwiftラッパー。64KBを確保し先頭にサイズを書き込む
+import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+final class FmoSharedMemory {
+    private let name: String
+    private let size: Int
+    private var ptr: UnsafeMutableRawPointer
+    private let fd: Int32
+
+    init(name: String, size: Int = 64 * 1024) throws {
+        self.name = name
+        self.size = size
+        let fdTemp = fmo_open_shared(name, size)
+        if fdTemp == -1 {
+            throw FmoError.systemError(String(cString: strerror(errno)))
+        }
+        fd = Int32(fdTemp)
+        // エフェメラルに運用するため作成直後に名前を削除
+        _ = fmo_shm_unlink(name)
+        guard let p = fmo_map(fdTemp, size) else {
+            fmo_close_fd(fdTemp)
+            throw FmoError.systemError("mmap failed")
+        }
+        ptr = p
+    }
+
+    /// 共有メモリの生ポインタへのアクセスを提供する
+    var pointer: UnsafeMutableRawPointer { ptr }
+
+    /// mutexで保護しながらデータを書き込む
+    func write(_ data: Data, mutex: FmoMutex) throws {
+        try mutex.lock()
+        defer { mutex.unlock() }
+        let len = min(data.count, size - 5)
+        data.withUnsafeBytes { bytes in
+            ptr.storeBytes(of: UInt32(len), as: UInt32.self)
+            memcpy(ptr.advanced(by: 4), bytes.baseAddress, len)
+            ptr.advanced(by: 4 + len).storeBytes(of: UInt8(0), as: UInt8.self)
+        }
+    }
+
+    /// mutexで保護しながらデータを読み出す
+    func read(mutex: FmoMutex) throws -> Data {
+        try mutex.lock()
+        defer { mutex.unlock() }
+        let len = ptr.load(as: UInt32.self)
+        return Data(bytes: ptr.advanced(by: 4), count: Int(len))
+    }
+
+    /// マップ解除と共有メモリの削除を行う
+    func close() {
+        fmo_munmap(ptr, size)
+        fmo_close_fd(fd)
+        fmo_shm_unlink(name)
+    }
+}

--- a/MacUkagaka/MacUkagaka-Bridging-Header.h
+++ b/MacUkagaka/MacUkagaka-Bridging-Header.h
@@ -1,0 +1,2 @@
+// Swift から C ブリッジを利用するためのヘッダー
+#import "FMO/FmoBridge.h"

--- a/MacUkagaka/MacUkagakaApp.swift
+++ b/MacUkagaka/MacUkagakaApp.swift
@@ -1,17 +1,34 @@
-//
-//  MacUkagakaApp.swift
-//  MacUkagaka
-//
-//  Created by eightman on 2025/07/26.
-//
-
 import SwiftUI
+import AppKit
+// FMO 機能を組み込み、起動時に初期化する
 
 @main
 struct MacUkagakaApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
+    }
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    var fmo: FmoManager?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // 起動時に FMO を初期化。既に起動していれば終了する
+        do {
+            fmo = try FmoManager()
+        } catch FmoError.alreadyRunning {
+            NSLog("Application already running")
+            NSApplication.shared.terminate(nil)
+        } catch {
+            NSLog("FMO init failed: \(error)")
+        }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        // 終了時に共有メモリとセマフォを開放
+        fmo?.cleanup()
     }
 }


### PR DESCRIPTION
## Summary
- remove shared memory name immediately after creation for crash-safe cleanup
- document ephemeral usage in Japanese docs

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6884ece50c9c8322bbebb57214866b4b