### PR TITLE
Add basic PLUGIN/2.0M host

### DIFF
--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import AppKit
+
+// Plugin host
+import Foundation
 // FMO 機能を組み込み、起動時に初期化する
 
 @main
@@ -14,6 +17,7 @@ struct OurinApp: App {
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     var fmo: FmoManager?
+    var pluginRegistry: PluginRegistry?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // 起動時に FMO を初期化。既に起動していれば終了する
@@ -25,10 +29,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } catch {
             NSLog("FMO init failed: \(error)")
         }
+
+        // プラグインを探索してロード
+        let registry = PluginRegistry()
+        registry.discoverAndLoad()
+        pluginRegistry = registry
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         // 終了時に共有メモリとセマフォを開放
         fmo?.cleanup()
+        pluginRegistry?.unloadAll()
     }
 }

--- a/Ourin/PluginHost/Plugin.swift
+++ b/Ourin/PluginHost/Plugin.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+// Function pointer types for PLUGIN/2.0M
+public typealias PluginRequestFn = @convention(c) (UnsafePointer<UInt8>, Int, UnsafeMutablePointer<Int>) -> UnsafePointer<UInt8>?
+public typealias PluginLoadFn = @convention(c) (UnsafePointer<CChar>) -> Int32
+public typealias PluginUnloadFn = @convention(c) () -> Void
+
+/// Single plugin bundle wrapper
+public struct Plugin {
+    let bundle: Bundle
+    let request: PluginRequestFn
+    let load: PluginLoadFn?
+    let unload: PluginUnloadFn?
+
+    public init(url: URL) throws {
+        guard let bundle = Bundle(url: url) else {
+            throw NSError(domain: "Plugin", code: -1, userInfo: [NSLocalizedDescriptionKey: "invalid bundle"])
+        }
+        self.bundle = bundle
+        // force load image
+        _ = bundle.principalClass
+        func sym<T>(_ name: String) -> T? {
+            let fp = CFBundleGetFunctionPointerForName(bundle._cfBundle, name as CFString)
+            guard fp != nil else { return nil }
+            return unsafeBitCast(fp, to: Optional<T>.self)
+        }
+        guard let req: PluginRequestFn = sym("request") else {
+            throw NSError(domain: "Plugin", code: -2, userInfo: [NSLocalizedDescriptionKey: "request not found"])
+        }
+        self.request = req
+        self.load = sym("load")
+        self.unload = sym("unload")
+    }
+
+    /// Send raw wire text to plugin and return response string (UTF-8)
+    public func send(_ text: String) -> String {
+        var outLen: Int = 0
+        var bytes = Array(text.utf8)
+        let respPtr = bytes.withUnsafeMutableBytes { raw -> UnsafePointer<UInt8>? in
+            return request(raw.bindMemory(to: UInt8.self).baseAddress!, bytes.count, &outLen)
+        }
+        guard let p = respPtr else { return "" }
+        let buf = UnsafeBufferPointer(start: p, count: outLen)
+        return String(decoding: buf, as: UTF8.self)
+    }
+}
+
+private extension Bundle {
+    var _cfBundle: CFBundle {
+        CFBundleGetBundleWithIdentifier(self.bundleIdentifier! as CFString)!
+    }
+}

--- a/Ourin/PluginHost/PluginRegistry.swift
+++ b/Ourin/PluginHost/PluginRegistry.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Parsed metadata from descript.txt
+public struct PluginMeta {
+    public let name: String
+    public let id: String
+    public let filename: String
+    public let secondChangeInterval: Int?
+    public let otherGhostTalk: Bool?
+}
+
+/// Registry for discovering and managing plugins
+public final class PluginRegistry {
+    public private(set) var plugins: [Plugin] = []
+    public private(set) var metas: [Plugin: PluginMeta] = [:]
+
+    public init() {}
+
+    /// Discover plugin bundles and load them
+    public func discoverAndLoad() {
+        for dir in PluginRegistry.searchPaths() {
+            guard let items = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]) else { continue }
+            for item in items where item.pathExtension == "plugin" || item.pathExtension == "bundle" {
+                do {
+                    let plug = try Plugin(url: item)
+                    if let load = plug.load {
+                        _ = load(item.path)
+                    }
+                    plugins.append(plug)
+                    if let meta = PluginRegistry.readMeta(from: plug.bundle) {
+                        metas[plug] = meta
+                    }
+                } catch {
+                    NSLog("Plugin load failed: \(error)")
+                }
+            }
+        }
+    }
+
+    /// Unload all loaded plugins
+    public func unloadAll() {
+        for p in plugins { p.unload?() }
+        plugins.removeAll()
+        metas.removeAll()
+    }
+
+    // MARK: Utilities
+    private static func searchPaths() -> [URL] {
+        var urls: [URL] = []
+        if let builtIn = Bundle.main.builtInPlugInsURL {
+            urls.append(builtIn)
+        }
+        if let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            urls.append(appSupport.appendingPathComponent("Ourin/PlugIns", isDirectory: true))
+        }
+        return urls
+    }
+
+    private static func readMeta(from bundle: Bundle) -> PluginMeta? {
+        guard let url = bundle.url(forResource: "descript", withExtension: "txt") else { return nil }
+        guard let raw = try? Data(contentsOf: url) else { return nil }
+        // Determine charset using first line if available
+        var encoding: String.Encoding = .utf8
+        if let firstLine = String(data: raw, encoding: .utf8)?.split(whereSeparator: { $0.isNewline }).first {
+            let lower = firstLine.lowercased()
+            if lower.starts(with: "charset") {
+                let value = lower.split(separator: ",", maxSplits: 1).last?.trimmingCharacters(in: .whitespaces) ?? ""
+                if ["shift_jis", "windows-31j", "cp932", "ms932", "sjis"].contains(value) {
+                    encoding = .shiftJIS
+                }
+            }
+        }
+        guard let text = String(data: raw, encoding: encoding) else { return nil }
+        var name = ""
+        var id = ""
+        var filename = ""
+        var second: Int? = nil
+        var other: Bool? = nil
+        for line in text.split(whereSeparator: { $0.isNewline }) {
+            let parts = line.split(separator: ",", maxSplits: 1).map { $0.trimmingCharacters(in: .whitespaces) }
+            guard parts.count == 2 else { continue }
+            let key = parts[0].lowercased()
+            let value = parts[1]
+            switch key {
+            case "name": name = value
+            case "id": id = value
+            case "filename": filename = value
+            case "secondchangeinterval": second = Int(value)
+            case "otherghosttalk": other = (value == "true" || value == "1")
+            default: break
+            }
+        }
+        guard !name.isEmpty, !id.isEmpty, !filename.isEmpty else { return nil }
+        return PluginMeta(name: name, id: id, filename: filename, secondChangeInterval: second, otherGhostTalk: other)
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple plugin loader based on PLUGIN/2.0M draft spec
- parse `descript.txt` metadata and load `.plugin` bundles
- hook plugin registry into the app lifecycle

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6884fed6bbe08322a46c3c0861d2fdb3