### PR TITLE
Implement HEADLINE host skeleton

### DIFF
--- a/Ourin/HeadlineHost/HeadlineModule.swift
+++ b/Ourin/HeadlineHost/HeadlineModule.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public typealias HeadlineExecuteFn = @convention(c) (UnsafePointer<UInt8>, Int, UnsafeMutablePointer<Int>) -> UnsafePointer<UInt8>?
+public typealias HeadlineLoadFn = @convention(c) (UnsafePointer<CChar>) -> Int32
+public typealias HeadlineUnloadFn = @convention(c) () -> Void
+
+/// Wrapper for a HEADLINE/2.0M module bundle
+public struct HeadlineModule {
+    let bundle: Bundle
+    let execute: HeadlineExecuteFn
+    let load: HeadlineLoadFn?
+    let unload: HeadlineUnloadFn?
+
+    public init(url: URL) throws {
+        guard let bundle = Bundle(url: url) else {
+            throw NSError(domain: "HeadlineModule", code: -1, userInfo: [NSLocalizedDescriptionKey: "invalid bundle"])
+        }
+        self.bundle = bundle
+        _ = bundle.principalClass // force load image
+        func sym<T>(_ name: String) -> T? {
+            let fp = CFBundleGetFunctionPointerForName(bundle._cfBundle, name as CFString)
+            guard fp != nil else { return nil }
+            return unsafeBitCast(fp, to: Optional<T>.self)
+        }
+        guard let exe: HeadlineExecuteFn = sym("execute") else {
+            throw NSError(domain: "HeadlineModule", code: -2, userInfo: [NSLocalizedDescriptionKey: "execute not found"])
+        }
+        self.execute = exe
+        self.load = sym("load")
+        self.unload = sym("unload")
+    }
+
+    /// Send raw wire text to the module and get UTF-8 response string
+    public func send(_ text: String) -> String {
+        var outLen: Int = 0
+        var bytes = Array(text.utf8)
+        let respPtr = bytes.withUnsafeMutableBytes { raw -> UnsafePointer<UInt8>? in
+            return execute(raw.bindMemory(to: UInt8.self).baseAddress!, bytes.count, &outLen)
+        }
+        guard let p = respPtr else { return "" }
+        let buf = UnsafeBufferPointer(start: p, count: outLen)
+        return String(decoding: buf, as: UTF8.self)
+    }
+}
+
+private extension Bundle {
+    var _cfBundle: CFBundle {
+        CFBundleGetBundleWithIdentifier(self.bundleIdentifier! as CFString)!
+    }
+}

--- a/Ourin/HeadlineHost/HeadlineRegistry.swift
+++ b/Ourin/HeadlineHost/HeadlineRegistry.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Parsed metadata from headline descript.txt
+public struct HeadlineMeta {
+    public let name: String
+    public let filename: String
+    public let url: String
+    public let openurl: String
+    public let charset: String.Encoding
+}
+
+/// Registry for discovering HEADLINE modules
+public final class HeadlineRegistry {
+    public private(set) var modules: [HeadlineModule] = []
+    public private(set) var metas: [HeadlineModule: HeadlineMeta] = [:]
+
+    public init() {}
+
+    /// Discover bundles and load them
+    public func discoverAndLoad() {
+        for dir in HeadlineRegistry.searchPaths() {
+            guard let items = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]) else { continue }
+            for item in items where item.pathExtension == "plugin" || item.pathExtension == "bundle" {
+                do {
+                    let mod = try HeadlineModule(url: item)
+                    mod.load?(item.path)
+                    modules.append(mod)
+                    if let meta = HeadlineRegistry.readMeta(from: mod.bundle) {
+                        metas[mod] = meta
+                    }
+                } catch {
+                    NSLog("Headline module load failed: \(error)")
+                }
+            }
+        }
+    }
+
+    public func unloadAll() {
+        for m in modules { m.unload?() }
+        modules.removeAll()
+        metas.removeAll()
+    }
+
+    // MARK: - Utilities
+    private static func searchPaths() -> [URL] {
+        var urls: [URL] = []
+        if let builtIn = Bundle.main.builtInPlugInsURL?.appendingPathComponent("Headline", isDirectory: true) {
+            urls.append(builtIn)
+        }
+        if let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            urls.append(appSupport.appendingPathComponent("Ourin/Headline", isDirectory: true))
+        }
+        return urls
+    }
+
+    private static func readMeta(from bundle: Bundle) -> HeadlineMeta? {
+        guard let url = bundle.url(forResource: "descript", withExtension: "txt") else { return nil }
+        guard let raw = try? Data(contentsOf: url) else { return nil }
+        // determine charset
+        var encoding: String.Encoding = .utf8
+        if let first = String(data: raw.prefix(128), encoding: .utf8)?.split(whereSeparator: { $0.isNewline }).first {
+            let lower = first.lowercased()
+            if lower.starts(with: "charset") {
+                let value = lower.split(separator: ",", maxSplits: 1).last?.trimmingCharacters(in: .whitespaces) ?? ""
+                if ["shift_jis","windows-31j","cp932","ms932","sjis"].contains(value) {
+                    encoding = .shiftJIS
+                }
+            }
+        }
+        guard let text = String(data: raw, encoding: encoding) else { return nil }
+        var name = ""
+        var filename = ""
+        var urlStr = ""
+        var openurl = ""
+        for line in text.split(whereSeparator: { $0.isNewline }) {
+            let parts = line.split(separator: ",", maxSplits: 1).map { $0.trimmingCharacters(in: .whitespaces) }
+            guard parts.count == 2 else { continue }
+            let key = parts[0].lowercased()
+            let value = parts[1]
+            switch key {
+            case "name": name = value
+            case "filename": filename = value
+            case "url": urlStr = value
+            case "openurl": openurl = value
+            case "charset":
+                if ["shift_jis","windows-31j","cp932","ms932","sjis"].contains(value.lowercased()) {
+                    encoding = .shiftJIS
+                }
+            default: break
+            }
+        }
+        guard !name.isEmpty, !filename.isEmpty else { return nil }
+        return HeadlineMeta(name: name, filename: filename, url: urlStr, openurl: openurl, charset: encoding)
+    }
+}

--- a/Ourin/HeadlineHost/HeadlineWireEngine.swift
+++ b/Ourin/HeadlineHost/HeadlineWireEngine.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Build HEADLINE/2.0M request and parse response
+public struct HeadlineWireEngine {
+    public static func buildRequest(path: String, charset: String.Encoding = .utf8) -> String {
+        let cs: String
+        switch charset {
+        case .shiftJIS: cs = "Shift_JIS"
+        default: cs = "UTF-8"
+        }
+        return "GET Headline HEADLINE/2.0M\r\nCharset: \(cs)\r\nOption: url\r\nPath: \(path)\r\n\r\n"
+    }
+
+    /// Parse HEADLINE response lines to array of (text,url)
+    public static func parseLines(_ response: String) -> [(String, String?)] {
+        var results: [(String, String?)] = []
+        for line in response.split(whereSeparator: { $0.isNewline }) {
+            guard line.hasPrefix("Headline:") else { continue }
+            let value = line.dropFirst("Headline:".count).trimmingCharacters(in: .whitespaces)
+            if let sep = value.firstIndex(of: "\u{01}") {
+                let text = String(value[..<sep])
+                let url = String(value[value.index(after: sep)...])
+                results.append((text, url))
+            } else {
+                results.append((String(value), nil))
+            }
+        }
+        return results
+    }
+}

--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -18,6 +18,7 @@ struct OurinApp: App {
 class AppDelegate: NSObject, NSApplicationDelegate {
     var fmo: FmoManager?
     var pluginRegistry: PluginRegistry?
+    var headlineRegistry: HeadlineRegistry?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // 起動時に FMO を初期化。既に起動していれば終了する
@@ -34,11 +35,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let registry = PluginRegistry()
         registry.discoverAndLoad()
         pluginRegistry = registry
+
+        // HEADLINE モジュールも探索してロード
+        let hRegistry = HeadlineRegistry()
+        hRegistry.discoverAndLoad()
+        headlineRegistry = hRegistry
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         // 終了時に共有メモリとセマフォを開放
         fmo?.cleanup()
         pluginRegistry?.unloadAll()
+        headlineRegistry?.unloadAll()
     }
 }

--- a/OurinTests/HeadlineWireTests.swift
+++ b/OurinTests/HeadlineWireTests.swift
@@ -1,0 +1,15 @@
+import Testing
+@testable import Ourin
+
+struct HeadlineWireTests {
+    @Test
+    func buildAndParse() async throws {
+        let req = HeadlineWireEngine.buildRequest(path: "/tmp/file")
+        #expect(req.contains("GET Headline"))
+        let resp = "Headline: hello\u{01}https://example.com\r\n\r\n"
+        let parsed = HeadlineWireEngine.parseLines(resp)
+        #expect(parsed.count == 1)
+        #expect(parsed.first?.0 == "hello")
+        #expect(parsed.first?.1 == "https://example.com")
+    }
+}


### PR DESCRIPTION
## Summary
- add initial HEADLINE/2.0M host implementation
- load HEADLINE bundles at launch
- add wire engine helper and parsing tests

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6885028951b483229c3235230fec98c4