### PR TITLE
Fix hashable conformance for plugin types

### DIFF
--- a/Ourin/HeadlineHost/HeadlineModule.swift
+++ b/Ourin/HeadlineHost/HeadlineModule.swift
@@ -5,7 +5,7 @@ public typealias HeadlineLoadFn = @convention(c) (UnsafePointer<CChar>) -> Int32
 public typealias HeadlineUnloadFn = @convention(c) () -> Void
 
 /// Wrapper for a HEADLINE/2.0M module bundle
-public struct HeadlineModule {
+public struct HeadlineModule: Hashable {
     let bundle: Bundle
     let execute: HeadlineExecuteFn
     let load: HeadlineLoadFn?
@@ -40,6 +40,16 @@ public struct HeadlineModule {
         guard let p = respPtr else { return "" }
         let buf = UnsafeBufferPointer(start: p, count: outLen)
         return String(decoding: buf, as: UTF8.self)
+    }
+}
+
+extension HeadlineModule {
+    public static func == (lhs: HeadlineModule, rhs: HeadlineModule) -> Bool {
+        lhs.bundle.bundleURL == rhs.bundle.bundleURL
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(bundle.bundleURL)
     }
 }
 

--- a/Ourin/PluginHost/Plugin.swift
+++ b/Ourin/PluginHost/Plugin.swift
@@ -6,7 +6,7 @@ public typealias PluginLoadFn = @convention(c) (UnsafePointer<CChar>) -> Int32
 public typealias PluginUnloadFn = @convention(c) () -> Void
 
 /// Single plugin bundle wrapper
-public struct Plugin {
+public struct Plugin: Hashable {
     let bundle: Bundle
     let request: PluginRequestFn
     let load: PluginLoadFn?
@@ -42,6 +42,16 @@ public struct Plugin {
         guard let p = respPtr else { return "" }
         let buf = UnsafeBufferPointer(start: p, count: outLen)
         return String(decoding: buf, as: UTF8.self)
+    }
+}
+
+extension Plugin {
+    public static func == (lhs: Plugin, rhs: Plugin) -> Bool {
+        lhs.bundle.bundleURL == rhs.bundle.bundleURL
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(bundle.bundleURL)
     }
 }
 


### PR DESCRIPTION
## Summary
- make `Plugin` conform to `Hashable`
- make `HeadlineModule` conform to `Hashable`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6885cbe137688322b5143a70c3f731c0