### PR TITLE
Implement WEB/1.0M basic handler

### DIFF
--- a/Ourin.xcodeproj/project.pbxproj
+++ b/Ourin.xcodeproj/project.pbxproj
@@ -397,7 +397,8 @@
 				DEVELOPMENT_TEAM = XBT5U5CHS8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+                               GENERATE_INFOPLIST_FILE = NO;
+                               INFOPLIST_FILE = Ourin/Resources/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -438,7 +439,8 @@
 				DEVELOPMENT_TEAM = XBT5U5CHS8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+                               GENERATE_INFOPLIST_FILE = NO;
+                               INFOPLIST_FILE = Ourin/Resources/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import ApplicationServices
 
 // Plugin host
 import Foundation
@@ -30,6 +31,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } catch {
             NSLog("FMO init failed: \(error)")
         }
+
+        // Register handler for x-ukagaka-link scheme early
+        WebHandler.shared.register()
 
         // プラグインを探索してロード
         let registry = PluginRegistry()

--- a/Ourin/Resources/Info.plist
+++ b/Ourin/Resources/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key><string>Ourin</string>
+    <key>CFBundleIdentifier</key><string>furin-lab.Ourin</string>
+    <key>CFBundleVersion</key><string>1</string>
+    <key>CFBundleShortVersionString</key><string>1.0</string>
+    <key>LSMinimumSystemVersion</key><string>10.15</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key><string>org.ukagaka.link</string>
+            <key>CFBundleURLSchemes</key>
+            <array><string>x-ukagaka-link</string></array>
+            <key>CFBundleTypeRole</key><string>Viewer</string>
+        </dict>
+    </array>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key><string>com.ourin.nar</string>
+            <key>UTTypeConformsTo</key>
+            <array><string>public.zip-archive</string></array>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key><array><string>nar</string></array>
+                <key>public.mime-type</key>
+                <array>
+                    <string>application/x-nar</string>
+                    <string>application/zip</string>
+                </array>
+            </dict>
+        </dict>
+    </array>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key><string>Ukagaka Archive</string>
+            <key>LSItemContentTypes</key>
+            <array><string>com.ourin.nar</string></array>
+            <key>CFBundleTypeRole</key><string>Viewer</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Ourin/Web/NarInstaller.swift
+++ b/Ourin/Web/NarInstaller.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public enum NarInstaller {
+    /// Download and install a NAR archive from https URL
+    public static func install(from urlString: String) {
+        guard let url = URL(string: urlString), url.scheme?.lowercased() == "https" else {
+            NSLog("[NarInstaller] invalid url: \(urlString)")
+            return
+        }
+        let task = URLSession.shared.downloadTask(with: url) { local, response, error in
+            if let error = error {
+                NSLog("[NarInstaller] download error: \(error)")
+                return
+            }
+            guard let local = local else { return }
+            NSLog("[NarInstaller] downloaded: \(local.path)")
+            // Placeholder: unzip and apply install.txt
+        }
+        task.resume()
+    }
+}

--- a/Ourin/Web/WebHandler.swift
+++ b/Ourin/Web/WebHandler.swift
@@ -1,0 +1,69 @@
+import AppKit
+import Foundation
+import ApplicationServices
+
+public final class WebHandler: NSObject {
+    public static let shared = WebHandler()
+
+    /// Register kAEGetURL handler for the custom scheme
+    public func register() {
+        let manager = NSAppleEventManager.shared()
+        manager.setEventHandler(self,
+                                andSelector: #selector(handleGetURLEvent(_:withReplyEvent:)),
+                                forEventClass: AEEventClass(kInternetEventClass),
+                                andEventID: AEEventID(kAEGetURL))
+    }
+
+    @objc private func handleGetURLEvent(_ event: NSAppleEventDescriptor,
+                                         withReplyEvent replyEvent: NSAppleEventDescriptor) {
+        guard let urlString = event.paramDescriptor(forKeyword: keyDirectObject)?.stringValue,
+              let url = URL(string: urlString) else { return }
+        handle(url: url)
+    }
+
+    private func handle(url: URL) {
+        guard url.scheme?.lowercased() == "x-ukagaka-link" else { return }
+        let schemePrefix = "x-ukagaka-link:"
+        let full = url.absoluteString
+        guard full.lowercased().hasPrefix(schemePrefix) else { return }
+        let spec = String(full.dropFirst(schemePrefix.count))
+        let params = WebHandler.parseForm(spec)
+
+        switch params["type"]?.lowercased() {
+        case "event":
+            let ghost = params["ghost"] ?? ""
+            let info = params["info"] ?? ""
+            NSLog("[Ourin] event ghost=\(ghost) info=\(info)")
+            _ = BridgeToSHIORI.handle(event: "OnXUkagakaLinkOpen", references: [info])
+        case "install":
+            if let enc = params["url"], let decoded = enc.removingPercentEncoding {
+                NSLog("[Ourin] install from URL \(decoded)")
+                NarInstaller.install(from: decoded)
+            }
+        case "homeurl":
+            if let enc = params["url"], let decoded = enc.removingPercentEncoding {
+                NSLog("[Ourin] homeurl \(decoded)")
+                NarInstaller.install(from: decoded)
+            }
+        default:
+            NSLog("[Ourin] unsupported type \(params["type"] ?? "nil")")
+        }
+    }
+
+    static func parseForm(_ s: String) -> [String:String] {
+        var dict: [String:String] = [:]
+        for pair in s.split(separator: "&") {
+            if let eq = pair.firstIndex(of: "=") {
+                let k = String(pair[..<eq])
+                let v = String(pair[pair.index(after: eq)...])
+                let kd = k.replacingOccurrences(of: "+", with: " ").removingPercentEncoding ?? k
+                let vd = v.replacingOccurrences(of: "+", with: " ").removingPercentEncoding ?? v
+                dict[kd] = vd
+            } else {
+                let key = String(pair)
+                dict[key] = ""
+            }
+        }
+        return dict
+    }
+}


### PR DESCRIPTION
## Summary
- add Info.plist registering `x-ukagaka-link` scheme and `.nar` UTI
- patch project settings to use the new Info.plist
- hook web handler registration in `AppDelegate`
- implement `WebHandler` for URL parsing and event dispatch
- stub `NarInstaller`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6885cee86c248322915b5f914d636108