### PR TITLE
Add initialization logging for FMO resources

### DIFF
--- a/Ourin/FMO/FmoManager.swift
+++ b/Ourin/FMO/FmoManager.swift
@@ -6,7 +6,11 @@ final class FmoManager {
     let memory: FmoSharedMemory
 
     /// 共有メモリとセマフォを初期化する
+    ///
+    /// 初期化時に使用するリソース名をログに出力しておくことで、
+    /// サンドボックス環境などでのパスのずれや権限不足を調査しやすくする。
     init(mutexName: String = "/ssp_mutex", sharedName: String = "/ssp_fmo") throws {
+        NSLog("FMO initializing: mutex=%@ shared=%@", mutexName, sharedName)
         mutex = try FmoMutex(name: mutexName)
         memory = try FmoSharedMemory(name: sharedName)
     }

--- a/Ourin/FMO/FmoMutex.swift
+++ b/Ourin/FMO/FmoMutex.swift
@@ -12,6 +12,7 @@ final class FmoMutex {
 
     init(name: String) throws {
         self.name = name
+        NSLog("Opening semaphore '%@'", name)
         sem = fmo_sem_open(name, O_CREAT | O_EXCL, 0o666, 1)
         if sem == nil {
             if errno == EEXIST {

--- a/Ourin/FMO/FmoSharedMemory.swift
+++ b/Ourin/FMO/FmoSharedMemory.swift
@@ -15,6 +15,7 @@ final class FmoSharedMemory {
     init(name: String, size: Int = 64 * 1024) throws {
         self.name = name
         self.size = size
+        NSLog("Opening shared memory '%@' (%d bytes)", name, size)
         let fdTemp = fmo_open_shared(name, size)
         if fdTemp == -1 {
             throw FmoError.systemError(String(cString: strerror(errno)))


### PR DESCRIPTION
## Summary
- log FMO resource names when initializing FmoManager
- log shared memory and semaphore names on creation

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6885d5ba56dc83228bba1f8138f1e701