### PR TITLE
Expand PLUGIN event dispatcher

### DIFF
--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -25,6 +25,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var pluginRegistry: PluginRegistry?
     var headlineRegistry: HeadlineRegistry?
     var eventBridge: EventBridge?
+    /// PLUGIN Event 配送用ディスパッチャ
+    var pluginDispatcher: PluginEventDispatcher?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // 起動時に FMO を初期化。既に起動していれば終了する
@@ -44,6 +46,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let registry = PluginRegistry()
         registry.discoverAndLoad()
         pluginRegistry = registry
+        // プラグイン読み込み後にディスパッチャを開始
+        pluginDispatcher = PluginEventDispatcher(registry: registry)
 
         // HEADLINE モジュールも探索してロード
         let hRegistry = HeadlineRegistry()
@@ -62,5 +66,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         pluginRegistry?.unloadAll()
         headlineRegistry?.unloadAll()
         eventBridge?.stop()
+        // PLUGIN ディスパッチャ停止
+        pluginDispatcher?.stop()
     }
 }

--- a/Ourin/PluginEvent/EncodingNormalizer.swift
+++ b/Ourin/PluginEvent/EncodingNormalizer.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// SJIS 受理→UTF-8 正規化ユーティリティ
+enum EncodingNormalizer {
+    /// 指定エンコーディングから UTF-8 へ変換する
+    static func utf8String(from data: Data, encoding: String.Encoding) -> String? {
+        if encoding == .utf8 {
+            return String(data: data, encoding: .utf8)
+        }
+        // Shift_JIS 系文字列を UTF-8 へ変換
+        if let str = String(data: data, encoding: encoding) {
+            return str
+        }
+        return nil
+    }
+}

--- a/Ourin/PluginEvent/PathNormalizer.swift
+++ b/Ourin/PluginEvent/PathNormalizer.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Windows 由来のパスを POSIX 形式へ変換するユーティリティ
+enum PathNormalizer {
+    /// パス文字列を POSIX 形式へ変換
+    static func posix(_ path: String) -> String {
+        if path.hasPrefix("file://") {
+            return path
+        }
+        // Windows 形式を file URL 経由で正規化
+        return URL(fileURLWithPath: path).path
+    }
+}

--- a/Ourin/PluginEvent/PluginEventDispatcher.swift
+++ b/Ourin/PluginEvent/PluginEventDispatcher.swift
@@ -1,0 +1,101 @@
+import Foundation
+import AppKit
+
+/// PLUGIN イベントをプラグインへ配送するディスパッチャ
+final class PluginEventDispatcher {
+    /// 登録済みプラグイン一覧
+    private let registry: PluginRegistry
+    /// OnSecondChange 用タイマー
+    private var timer: DispatchSourceTimer?
+
+    /// 初期化時にプラグインメタ情報を参照してタイマーを開始する
+    init(registry: PluginRegistry) {
+        self.registry = registry
+        setupTimer()
+        sendVersion()
+    }
+
+    // MARK: - Timer
+    /// `secondchangeinterval` に従い DispatchSourceTimer を生成
+    private func setupTimer() {
+        let interval = registry.metas.values.compactMap { $0.secondChangeInterval }.min() ?? 0
+        guard interval > 0 else { return }
+        let t = DispatchSource.makeTimerSource()
+        t.schedule(deadline: .now() + .seconds(interval), repeating: .seconds(interval))
+        t.setEventHandler { [weak self] in
+            self?.onSecondChange()
+        }
+        t.resume()
+        timer = t
+    }
+
+    /// ディスパッチャを停止
+    func stop() { timer?.cancel() }
+
+    // MARK: - Event helpers
+    /// フレームを構築し全プラグインへ送信する
+    private func sendFrame(id: String, refs: [String], notify: Bool = false) {
+        let frame = PluginFrame(id: id, references: refs, notify: notify)
+        let req = frame.build()
+        for plugin in registry.plugins {
+            _ = plugin.send(req)
+        }
+    }
+
+    /// version イベントを全プラグインへ送信し応答を受け取る
+    private func sendVersion() {
+        for plugin in registry.plugins {
+            let req = PluginFrame(id: "version").build()
+            _ = plugin.send(req)
+        }
+    }
+
+    /// 秒周期イベント
+    func onSecondChange() { sendFrame(id: "OnSecondChange", refs: []) }
+
+    /// ゴースト起動時イベント
+    func onGhostBoot(windows: [NSWindow], ghostName: String, shellName: String, ghostID: String, path: String) {
+        let ref0 = WindowIDMapper.ids(for: windows)
+        let pathPosix = PathNormalizer.posix(path)
+        sendFrame(id: "OnGhostBoot", refs: [ref0, ghostName, shellName, ghostID, pathPosix])
+    }
+
+    /// メニュー実行時イベント
+    func onMenuExec(windows: [NSWindow], ghostName: String, shellName: String, ghostID: String, path: String) {
+        let ref0 = WindowIDMapper.ids(for: windows)
+        let pathPosix = PathNormalizer.posix(path)
+        sendFrame(id: "OnMenuExec", refs: [ref0, ghostName, shellName, ghostID, pathPosix])
+    }
+
+    /// インストール完了イベント
+    func onInstallComplete(type: String, name: String, path: String) {
+        let pathPosix = PathNormalizer.posix(path)
+        sendFrame(id: "OnInstallComplete", refs: [type, name, pathPosix])
+    }
+
+    /// ゴースト終了通知（NOTIFY）
+    func onGhostExit(windows: [NSWindow], ghostName: String, shellName: String, ghostID: String, path: String) {
+        let ref0 = WindowIDMapper.ids(for: windows)
+        let pathPosix = PathNormalizer.posix(path)
+        sendFrame(id: "OnGhostExit", refs: [ref0, ghostName, shellName, ghostID, pathPosix], notify: true)
+    }
+
+    /// ゴースト情報更新通知（NOTIFY）
+    func onGhostInfoUpdate(windows: [NSWindow], ghostName: String, shellName: String, ghostID: String, path: String) {
+        let ref0 = WindowIDMapper.ids(for: windows)
+        let pathPosix = PathNormalizer.posix(path)
+        sendFrame(id: "OnGhostInfoUpdate", refs: [ref0, ghostName, shellName, ghostID, pathPosix], notify: true)
+    }
+
+    /// その他ゴーストのトークイベント
+    func onOtherGhostTalk(ghostName: String, baseName: String, reasons: String, eventID: String, script: String, refs: [String]) {
+        var arr = [ghostName, baseName, reasons, eventID, script]
+        arr.append(contentsOf: refs)
+        sendFrame(id: "OnOtherGhostTalk", refs: arr)
+    }
+
+    /// 選択/アンカー選択等の横流しイベント
+    func onArbitraryEvent(id: String, refs: [String], notify: Bool = false) {
+        sendFrame(id: id, refs: refs, notify: notify)
+    }
+}

--- a/Ourin/PluginEvent/PluginFrame.swift
+++ b/Ourin/PluginEvent/PluginFrame.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// PLUGIN/2.0M フレーム構築用構造体
+struct PluginFrame {
+    /// イベント ID
+    var id: String
+    /// Reference パラメータ群
+    var references: [String] = []
+    /// 送信時の文字コード（既定 UTF-8）
+    var charset: String = "UTF-8"
+    /// GET か NOTIFY かを示す
+    var notify: Bool = false
+
+    /// 文字列フレームを組み立てる
+    func build() -> String {
+        var lines: [String] = []
+        let method = notify ? "NOTIFY" : "GET"
+        lines.append("\(method) PLUGIN/2.0M")
+        lines.append("Charset: \(charset)")
+        lines.append("ID: \(id)")
+        lines.append("Sender: Ourin")
+        for (i, ref) in references.enumerated() {
+            lines.append("Reference\(i): \(ref)")
+        }
+        lines.append("")
+        // CRLF 区切りで末尾にも CRLF
+        return lines.joined(separator: "\r\n") + "\r\n"
+    }
+}

--- a/Ourin/PluginEvent/WindowIDMapper.swift
+++ b/Ourin/PluginEvent/WindowIDMapper.swift
@@ -1,0 +1,11 @@
+import AppKit
+import CoreGraphics
+
+/// NSWindow から CGWindowID 列を生成するユーティリティ
+enum WindowIDMapper {
+    /// 複数ウィンドウの ID をカンマ区切りで取得
+    static func ids(for windows: [NSWindow]) -> String {
+        let ids = windows.map { String(CGWindowID($0.windowNumber)) }
+        return ids.joined(separator: ",")
+    }
+}


### PR DESCRIPTION
## Summary
- add EncodingNormalizer utility
- extend `PluginFrame` with NOTIFY support and Japanese docs
- expand `PluginEventDispatcher` to send various events, version requests, and add Japanese comments
- document plugin dispatcher usage in `OurinApp`

## Testing
- `swiftc -typecheck Ourin/PluginEvent/PluginEventDispatcher.swift` *(fails: no such module 'AppKit')*
- `swiftc -dump-ast Ourin/PluginEvent/PluginFrame.swift`


------
https://chatgpt.com/codex/tasks/task_e_688626bc904c8322855bb196f72259a1