### PR TITLE
Implement external SSTP server stack

### DIFF
--- a/Ourin/ExternalServer/EncodingNormalizer.swift
+++ b/Ourin/ExternalServer/EncodingNormalizer.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// 文字セットラベルに応じてデータをデコードするユーティリティ。
+public enum EncodingNormalizer {
+    /// Charset ヘッダが存在する場合はそれを利用し、UTF‑8 または CP932 として解釈する。
+    public static func decode(_ data: Data, charset: String?) -> String? {
+        if let cs = charset { return EncodingAdapter.decode(data, charset: cs) }
+        if let utf = String(data: data, encoding: .utf8) { return utf }
+        return String(data: data, encoding: .shiftJIS)
+    }
+}

--- a/Ourin/ExternalServer/OurinExternalServer.swift
+++ b/Ourin/ExternalServer/OurinExternalServer.swift
@@ -1,0 +1,33 @@
+import Foundation
+import OSLog
+
+/// 外部からの SSTP イベントを受信する TCP/HTTP/XPC サーバ群を管理するクラス。
+public final class OurinExternalServer {
+    private let tcp = SstpTcpServer()
+    private let http = SstpHttpServer()
+    private let xpc = XpcDirectServer()
+    private let router = SstpRouter()
+    private let logger = Logger(subsystem: "Ourin", category: "ExternalServer")
+
+    public init() {
+        tcp.onRequest = { [weak self] in self?.router.handle(raw: $0) ?? "" }
+        http.onRequest = { [weak self] in self?.router.handle(raw: $0) ?? "" }
+        xpc.onRequest = { [weak self] in self?.router.handle(raw: $0) ?? "" }
+    }
+
+    /// すべてのリスナーを起動する。エラーは現状無視する。
+    public func start() {
+        try? tcp.start()
+        try? http.start()
+        xpc.start()
+        logger.info("external servers started")
+    }
+
+    /// すべてのリスナーを停止する。
+    public func stop() {
+        tcp.stop()
+        http.stop()
+        xpc.stop()
+        logger.info("external servers stopped")
+    }
+}

--- a/Ourin/ExternalServer/ServerMetrics.swift
+++ b/Ourin/ExternalServer/ServerMetrics.swift
@@ -1,0 +1,29 @@
+import Foundation
+import OSLog
+
+/// 簡易メトリクス集計
+final class ServerMetrics {
+    static let shared = ServerMetrics()
+    private init() {}
+
+    private var count: Int = 0
+    private var error: Int = 0
+    private var totalTime: TimeInterval = 0
+    private let queue = DispatchQueue(label: "Ourin.metrics")
+
+    func record(duration: TimeInterval, error: Bool) {
+        queue.async {
+            self.count += 1
+            self.totalTime += duration
+            if error { self.error += 1 }
+        }
+    }
+
+    var averageLatency: TimeInterval {
+        queue.sync { count > 0 ? totalTime / Double(count) : 0 }
+    }
+
+    var errorRate: Double {
+        queue.sync { count > 0 ? Double(error) / Double(count) : 0 }
+    }
+}

--- a/Ourin/ExternalServer/SstpHttpServer.swift
+++ b/Ourin/ExternalServer/SstpHttpServer.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Network
+import OSLog
+
+/// HTTP 経由で SSTP メッセージを受信する簡易サーバ。
+public final class SstpHttpServer {
+    private var listener: NWListener?
+    public var onRequest: ((String) -> String)?
+    private let logger = Logger(subsystem: "Ourin", category: "SSTP_HTTP")
+    private let timeout: TimeInterval = 5
+    private let maxSize = 64 * 1024
+
+    public init() {}
+
+    public func start(host: String = "127.0.0.1", port: UInt16 = 9810) throws {
+        listener = try NWListener(using: .tcp, on: NWEndpoint.Port(rawValue: port)!)
+        listener?.newConnectionHandler = { [weak self] conn in
+            guard let self else { return }
+            conn.start(queue: .global())
+            self.handle(conn: conn)
+        }
+        listener?.start(queue: .main)
+        logger.info("listen \(host):\(port)")
+    }
+
+    public func stop() { listener?.cancel(); listener = nil }
+
+    private func handle(conn: NWConnection) {
+        var buffer = Data()
+        let deadline = DispatchTime.now() + timeout
+        func readMore() {
+            conn.receive(minimumIncompleteLength: 1, maximumLength: 8192) { data, _, isComplete, error in
+                if let d = data { buffer.append(d) }
+                if buffer.count > self.maxSize { self.send400(conn); return }
+                if DispatchTime.now() > deadline { self.send400(conn); return }
+                if isComplete || error != nil { conn.cancel(); return }
+                if let headerEnd = buffer.range(of: Data([13,10,13,10])) {
+                    let header = buffer.subdata(in: 0..<headerEnd.upperBound)
+                    let headersText = String(data: header, encoding: .utf8) ?? ""
+                    var contentLength = 0
+                    for rawLine in headersText.split(separator: "\n") {
+                        let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if line.lowercased().hasPrefix("content-length:") {
+                            let v = line.split(separator: ":", maxSplits: 1)[1].trimmingCharacters(in: .whitespaces)
+                            contentLength = Int(v) ?? 0
+                        }
+                    }
+                    let bodyStart = headerEnd.upperBound
+                    if buffer.count - bodyStart >= contentLength {
+                        let body = buffer.subdata(in: bodyStart..<bodyStart+contentLength)
+                        if let sstp = Self.decode(body) {
+                            let start = Date()
+                            let respSstp = self.onRequest?(sstp) ?? "SSTP/1.1 204 No Content\r\n\r\n"
+                            let duration = Date().timeIntervalSince(start)
+                            let lines = [
+                                "HTTP/1.1 200 OK\r",
+                                "Content-Type: text/plain; charset=UTF-8\r",
+                                "Content-Length: \(respSstp.utf8.count)\r",
+                                "\r",
+                                respSstp
+                            ]
+                            let http = lines.joined()
+                            self.logger.info("http size=\(buffer.count) duration=\(duration)")
+                            ServerMetrics.shared.record(duration: duration, error: false)
+                            conn.send(content: http.data(using: .utf8), completion: .contentProcessed { _ in conn.cancel() })
+                            return
+                        }
+                    }
+                }
+                readMore()
+            }
+        }
+        readMore()
+    }
+
+    private static func decode(_ data: Data) -> String? {
+        if let s = String(data: data, encoding: .utf8) { return s }
+        return String(data: data, encoding: .shiftJIS)
+    }
+
+    private func send400(_ conn: NWConnection) {
+        let resp = "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n"
+        logger.fault("http error")
+        ServerMetrics.shared.record(duration: 0, error: true)
+        conn.send(content: resp.data(using: .utf8), completion: .contentProcessed { _ in conn.cancel() })
+    }
+}

--- a/Ourin/ExternalServer/SstpParser.swift
+++ b/Ourin/ExternalServer/SstpParser.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// SSTP/1.x メッセージを表す構造体。メソッド・バージョン・ヘッダを保持する。
+public struct SstpMessage {
+    public let method: String
+    public let version: String
+    public let headers: [String:String]
+}
+
+public enum SstpParser {
+    /// CRLF 区切りの生SSTP文字列を解析する。
+    public static func parse(_ raw: String) -> SstpMessage? {
+        let lines = raw.replacingOccurrences(of: "\r\n", with: "\n")
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        guard let first = lines.first else { return nil }
+        let comps = first.split(separator: " ")
+        guard comps.count >= 2 else { return nil }
+        var headers: [String:String] = [:]
+        for line in lines.dropFirst() {
+            if line.isEmpty { break }
+            if let idx = line.firstIndex(of: ":") {
+                let key = String(line[..<idx]).trimmingCharacters(in: .whitespaces)
+                let val = String(line[line.index(after: idx)...]).trimmingCharacters(in: .whitespaces)
+                headers[key] = val
+            }
+        }
+        return SstpMessage(method: String(comps[0]), version: String(comps[1]), headers: headers)
+    }
+}

--- a/Ourin/ExternalServer/SstpRouter.swift
+++ b/Ourin/ExternalServer/SstpRouter.swift
@@ -1,0 +1,44 @@
+import Foundation
+import OSLog
+
+/// 解析済みの SSTP メッセージを SHIORI ブリッジへルーティングする。
+public final class SstpRouter {
+    private let logger = Logger(subsystem: "Ourin", category: "ExternalSSTP")
+    public init() {}
+
+    /// 生の SSTP 文字列を処理し、SSTP 形式の応答を返す。
+    public func handle(raw: String) -> String {
+        let start = Date()
+        guard let msg = SstpParser.parse(raw) else {
+            logger.fault("parse failure")
+            ServerMetrics.shared.record(duration: 0, error: true)
+            return "SSTP/1.1 400 Bad Request\r\n\r\n"
+        }
+        let charset = msg.headers["Charset"] ?? "UTF-8"
+        let event = msg.headers["Event"] ?? ""
+        var refs: [String] = []
+        for i in 0..<16 {
+            if let v = msg.headers["Reference\(i)"] { refs.append(v) } else { break }
+        }
+        let script = BridgeToSHIORI.handle(event: event, references: refs)
+        let isNotify = msg.method.uppercased() == "NOTIFY"
+        let duration = Date().timeIntervalSince(start)
+        let resp: String
+        if isNotify {
+            resp = "SSTP/1.1 204 No Content\r\n\r\n"
+        } else {
+            let lines = [
+                "SSTP/1.1 200 OK",
+                "Charset: \(charset)",
+                "Sender: Ourin",
+                "Script: \(script)",
+                "",
+                ""
+            ]
+            resp = lines.joined(separator: "\r\n")
+        }
+        logger.info("event=\(event, privacy: .public) duration=\(duration)")
+        ServerMetrics.shared.record(duration: duration, error: false)
+        return resp
+    }
+}

--- a/Ourin/ExternalServer/SstpTcpServer.swift
+++ b/Ourin/ExternalServer/SstpTcpServer.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Network
+import OSLog
+
+/// TCP 経由で SSTP メッセージを受信する簡易サーバ。
+public final class SstpTcpServer {
+    private var listener: NWListener?
+    public var onRequest: ((String) -> String)?
+    private let logger = Logger(subsystem: "Ourin", category: "SSTP_TCP")
+    private let timeout: TimeInterval = 5
+    private let maxSize = 64 * 1024
+
+    public init() {}
+
+    public func start(host: String = "127.0.0.1", port: UInt16 = 9801) throws {
+        let params = NWParameters.tcp
+        listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
+        listener?.newConnectionHandler = { [weak self] conn in
+            guard let self else { return }
+            conn.start(queue: .global())
+            self.handle(conn: conn)
+        }
+        listener?.start(queue: .main)
+        logger.info("listen \(host):\(port)")
+    }
+
+    public func stop() { listener?.cancel(); listener = nil }
+
+    private func handle(conn: NWConnection) {
+        var buffer = Data()
+        let deadline = DispatchTime.now() + timeout
+        func readMore() {
+            conn.receive(minimumIncompleteLength: 1, maximumLength: 4096) { data, _, isComplete, error in
+                if let d = data { buffer.append(d) }
+                if buffer.count > self.maxSize { self.send400(conn); return }
+                if DispatchTime.now() > deadline { self.send400(conn); return }
+                if isComplete || error != nil { conn.cancel(); return }
+                if let range = buffer.range(of: Data([13,10,13,10])) {
+                    let header = buffer.subdata(in: 0..<range.lowerBound)
+                    if let text = Self.decode(header) {
+                        let start = Date()
+                        let resp = self.onRequest?(text) ?? "SSTP/1.1 204 No Content\r\n\r\n"
+                        let duration = Date().timeIntervalSince(start)
+                        self.logger.info("tcp request size=\(buffer.count) duration=\(duration)")
+                        ServerMetrics.shared.record(duration: duration, error: false)
+                        conn.send(content: resp.data(using: .utf8), completion: .contentProcessed { _ in conn.cancel() })
+                        return
+                    }
+                }
+                readMore()
+            }
+        }
+        readMore()
+    }
+
+    private static func decode(_ data: Data) -> String? {
+        if let s = String(data: data, encoding: .utf8) { return s }
+        return String(data: data, encoding: .shiftJIS)
+    }
+
+    private func send400(_ conn: NWConnection) {
+        let resp = "SSTP/1.1 400 Bad Request\r\n\r\n"
+        logger.fault("tcp error")
+        ServerMetrics.shared.record(duration: 0, error: true)
+        conn.send(content: resp.data(using: .utf8), completion: .contentProcessed { _ in conn.cancel() })
+    }
+}

--- a/Ourin/ExternalServer/XpcDirectServer.swift
+++ b/Ourin/ExternalServer/XpcDirectServer.swift
@@ -1,0 +1,47 @@
+import Foundation
+import OSLog
+
+/// XPC 経由で SSTP メッセージを受信するサーバ。
+@objc public protocol OurinExternalSstpXPC {
+    func deliverSSTP(_ request: Data, with reply: @escaping (Data) -> Void)
+}
+
+public final class XpcDirectServer: NSObject, NSXPCListenerDelegate, OurinExternalSstpXPC {
+    private let listener: NSXPCListener
+    public var onRequest: ((String) -> String)?
+    private let logger = Logger(subsystem: "Ourin", category: "SSTP_XPC")
+    private let maxSize = 512 * 1024
+
+    public init(machServiceName: String = "jp.ourin.sstp") {
+        self.listener = NSXPCListener(machServiceName: machServiceName)
+        super.init()
+        self.listener.delegate = self
+    }
+
+    public func start() { listener.resume(); logger.info("xpc started") }
+    public func stop() { listener.invalidate() }
+
+    public func listener(_ listener: NSXPCListener, shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
+        newConnection.exportedInterface = NSXPCInterface(with: OurinExternalSstpXPC.self)
+        newConnection.exportedObject = self
+        newConnection.resume()
+        return true
+    }
+
+    /// XPC クライアントから SSTP データを受け取り応答する。
+    public func deliverSSTP(_ request: Data, with reply: @escaping (Data) -> Void) {
+        guard request.count <= maxSize else {
+            logger.fault("xpc oversized")
+            ServerMetrics.shared.record(duration: 0, error: true)
+            reply(Data("SSTP/1.1 400 Bad Request\r\n\r\n".utf8))
+            return
+        }
+        let str = String(data: request, encoding: .utf8) ?? String(data: request, encoding: .shiftJIS) ?? ""
+        let start = Date()
+        let resp = onRequest?(str) ?? "SSTP/1.1 204 No Content\r\n\r\n"
+        let duration = Date().timeIntervalSince(start)
+        logger.info("xpc size=\(request.count) duration=\(duration)")
+        ServerMetrics.shared.record(duration: duration, error: false)
+        reply(Data(resp.utf8))
+    }
+}

--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -25,6 +25,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var pluginRegistry: PluginRegistry?
     var headlineRegistry: HeadlineRegistry?
     var eventBridge: EventBridge?
+    /// 外部 SHIORI イベントサーバ
+    var externalServer: OurinExternalServer?
     /// PLUGIN Event 配送用ディスパッチャ
     var pluginDispatcher: PluginEventDispatcher?
 
@@ -58,6 +60,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let bridge = EventBridge.shared
         bridge.start()
         eventBridge = bridge
+
+        // 外部 SSTP サーバを起動
+        let ext = OurinExternalServer()
+        ext.start()
+        externalServer = ext
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -66,6 +73,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         pluginRegistry?.unloadAll()
         headlineRegistry?.unloadAll()
         eventBridge?.stop()
+        externalServer?.stop()
         // PLUGIN ディスパッチャ停止
         pluginDispatcher?.stop()
     }

--- a/OurinTests/ExternalServerTests.swift
+++ b/OurinTests/ExternalServerTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import Ourin
+
+struct ExternalServerTests {
+    @Test
+    func parser() throws {
+        let raw = "NOTIFY SSTP/1.1\r\nSender: Test\r\nEvent: Foo\r\nCharset: UTF-8\r\n\r\n"
+        let msg = SstpParser.parse(raw)
+        #expect(msg?.method == "NOTIFY")
+        #expect(msg?.headers["Event"] == "Foo")
+    }
+
+    @Test
+    func routerNotify() throws {
+        let raw = "NOTIFY SSTP/1.1\r\nSender: Test\r\nEvent: Bar\r\nCharset: UTF-8\r\n\r\n"
+        let router = SstpRouter()
+        let resp = router.handle(raw: raw)
+        #expect(resp.contains("204"))
+    }
+
+    @Test
+    func routerSend() throws {
+        let raw = "SEND SSTP/1.1\r\nSender: Test\r\nEvent: Baz\r\nCharset: UTF-8\r\n\r\n"
+        let router = SstpRouter()
+        let resp = router.handle(raw: raw)
+        #expect(resp.contains("200"))
+    }
+}


### PR DESCRIPTION
## Summary
- add server metrics and basic OSLog output
- enforce simple timeouts and request size limits
- record metrics for TCP, HTTP and XPC deliveries
- log startup and shutdown of external servers
- expand external server tests
- convert external server comments to Japanese

## Testing
- `swift test` *(fails: Package.swift not found)*

------
https://chatgpt.com/codex/tasks/task_e_68862b5fcd0c8322965f2e8ce4e1297d