### PR TITLE
Fix compilation issues

### DIFF
--- a/Ourin/HeadlineHost/HeadlineRegistry.swift
+++ b/Ourin/HeadlineHost/HeadlineRegistry.swift
@@ -23,7 +23,9 @@ public final class HeadlineRegistry {
             for item in items where item.pathExtension == "plugin" || item.pathExtension == "bundle" {
                 do {
                     let mod = try HeadlineModule(url: item)
-                    mod.load?(item.path)
+                    if let load = mod.load {
+                        _ = load(item.path)
+                    }
                     modules.append(mod)
                     if let meta = HeadlineRegistry.readMeta(from: mod.bundle) {
                         metas[mod] = meta

--- a/Ourin/PluginEvent/PluginEncodingNormalizer.swift
+++ b/Ourin/PluginEvent/PluginEncodingNormalizer.swift
@@ -6,7 +6,7 @@ private extension String.Encoding {
 }
 
 /// SJIS 受理→UTF-8 正規化ユーティリティ
-enum EncodingNormalizer {
+enum PluginEncodingNormalizer {
     /// 文字コードラベルから `String.Encoding` を得る
     static func encoding(from label: String) -> String.Encoding {
         let lower = label.lowercased()

--- a/Ourin/Property/MachSupport.swift
+++ b/Ourin/Property/MachSupport.swift
@@ -5,5 +5,7 @@
 //  Created by eightman on 2025/07/27.
 //
 
+import Darwin
+
 let HOST_VM_INFO64_COUNT: mach_msg_type_number_t =
     UInt32(MemoryLayout<vm_statistics64_data_t>.size / MemoryLayout<integer_t>.size)

--- a/Samples/PLUGIN_2_0M/swift_host/PluginHost.swift
+++ b/Samples/PLUGIN_2_0M/swift_host/PluginHost.swift
@@ -4,7 +4,7 @@ typealias ReqFn = @convention(c) (UnsafePointer<UInt8>, Int, UnsafeMutablePointe
 typealias LoadFn = @convention(c) (UnsafePointer<CChar>) -> Int32
 typealias UnloadFn = @convention(c) () -> Void
 
-public struct Plugin {
+public struct SamplePlugin {
     let bundle: Bundle
     let request: ReqFn
     let load: LoadFn?


### PR DESCRIPTION
## Summary
- rename sample Plugin host struct to avoid collision
- rename EncodingNormalizer util for plugin events
- fix unused result in HeadlineRegistry
- expose HOST_VM_INFO64_COUNT constant

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68863299267c8322b09f87e6fa834cb6