### PR TITLE
Fix sandbox errors by adding network entitlements

### DIFF
--- a/Ourin/Ourin.entitlements
+++ b/Ourin/Ourin.entitlements
@@ -6,5 +6,10 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
+    <!-- Allow SSTP TCP/HTTP listeners and HTTP client connections -->
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- add `com.apple.security.network.server` and `com.apple.security.network.client` to `Ourin.entitlements`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6887328eb72883229e8d0b292a6b091a