### PR TITLE
Implement basic macOS SHIORI events

### DIFF
--- a/Ourin/SHIORIEvents/SleepObserver.swift
+++ b/Ourin/SHIORIEvents/SleepObserver.swift
@@ -1,0 +1,35 @@
+import AppKit
+
+// SleepObserver.swift
+// Observe system sleep/wake and screen sleep as SHIORI events
+
+final class SleepObserver {
+    static let shared = SleepObserver()
+    private init() {}
+
+    private var tokens: [Any] = []
+    private var handler: ((ShioriEvent) -> Void)?
+
+    func start(_ handler: @escaping (ShioriEvent) -> Void) {
+        self.handler = handler
+        let center = NSWorkspace.shared.notificationCenter
+        tokens.append(center.addObserver(forName: NSWorkspace.willSleepNotification, object: nil, queue: .main) { [weak self] _ in
+            self?.handler?(ShioriEvent(id: "OnSysSuspend", params: [:]))
+        })
+        tokens.append(center.addObserver(forName: NSWorkspace.didWakeNotification, object: nil, queue: .main) { [weak self] _ in
+            self?.handler?(ShioriEvent(id: "OnSysResume", params: [:]))
+        })
+        tokens.append(center.addObserver(forName: NSWorkspace.screensDidSleepNotification, object: nil, queue: .main) { [weak self] _ in
+            self?.handler?(ShioriEvent(id: "OnScreenSaverStart", params: [:]))
+        })
+        tokens.append(center.addObserver(forName: NSWorkspace.screensDidWakeNotification, object: nil, queue: .main) { [weak self] _ in
+            self?.handler?(ShioriEvent(id: "OnScreenSaverEnd", params: [:]))
+        })
+    }
+
+    func stop() {
+        let center = NSWorkspace.shared.notificationCenter
+        for t in tokens { center.removeObserver(t) }
+        tokens.removeAll()
+    }
+}

--- a/Ourin/SHIORIEvents/TimerEmitter.swift
+++ b/Ourin/SHIORIEvents/TimerEmitter.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+// TimerEmitter.swift
+// Periodic timers for OnIdle and OnMinuteChange events
+
+final class TimerEmitter {
+    static let shared = TimerEmitter()
+    private init() {}
+
+    private var idleTimer: DispatchSourceTimer?
+    private var minuteTimer: DispatchSourceTimer?
+    private var handler: ((ShioriEvent) -> Void)?
+
+    /// Start emitting timer based events
+    func start(_ handler: @escaping (ShioriEvent) -> Void) {
+        self.handler = handler
+
+        let idle = DispatchSource.makeTimerSource()
+        idle.schedule(deadline: .now() + .seconds(1), repeating: .seconds(1))
+        idle.setEventHandler { [weak self] in
+            self?.handler?(ShioriEvent(id: "OnIdle", params: [:]))
+        }
+        idle.resume()
+        idleTimer = idle
+
+        let minute = DispatchSource.makeTimerSource()
+        minute.schedule(deadline: .now() + .seconds(60), repeating: .seconds(60))
+        minute.setEventHandler { [weak self] in
+            self?.handler?(ShioriEvent(id: "OnMinuteChange", params: [:]))
+        }
+        minute.resume()
+        minuteTimer = minute
+    }
+
+    /// Stop timers
+    func stop() {
+        idleTimer?.cancel(); idleTimer = nil
+        minuteTimer?.cancel(); minuteTimer = nil
+    }
+}


### PR DESCRIPTION
## Summary
- add `TimerEmitter` for `OnIdle` and `OnMinuteChange`
- add `SleepObserver` for suspend/resume and screen saver events
- extend `EventBridge` to start/stop the new observers
- send `OnBoot` and `OnClose` events via GET
- generalise `ShioriDispatcher` to build GET/NOTIFY requests

## Testing
- `swiftc` compilation attempted for new files (fails: `no such module 'AppKit'` on Linux)

------
https://chatgpt.com/codex/tasks/task_e_688734269c188322b1a9c930f76c373c