### PR TITLE
Add custom icon for .nar documents

### DIFF
--- a/Ourin/Resources/Info.plist
+++ b/Ourin/Resources/Info.plist
@@ -40,6 +40,7 @@
             <key>LSItemContentTypes</key>
             <array><string>com.ourin.nar</string></array>
             <key>CFBundleTypeRole</key><string>Viewer</string>
+            <key>CFBundleTypeIconFile</key><string>Ourin.icns</string>
         </dict>
     </array>
 </dict>

--- a/Samples/OURIN_WEB/Info_ukagaka_link_and_nar.plist
+++ b/Samples/OURIN_WEB/Info_ukagaka_link_and_nar.plist
@@ -40,6 +40,7 @@
       <key>LSItemContentTypes</key>
       <array><string>com.ourin.nar</string></array>
       <key>CFBundleTypeRole</key><string>Viewer</string>
+      <key>CFBundleTypeIconFile</key><string>Ourin.icns</string>
     </dict>
   </array>
 </dict>


### PR DESCRIPTION
## Summary
- set `Ourin.icns` as the icon for `.nar` archives

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68874a8189548322b151a2dd51e43267