### PR TITLE
Fix missing OnLocaleChange event ID

### DIFF
--- a/Ourin/SHIORIEvents/EventID.swift
+++ b/Ourin/SHIORIEvents/EventID.swift
@@ -71,6 +71,7 @@ public enum EventID: String, CaseIterable {
     case OnKeyDown = "OnKeyDown" // M-Add
     case OnKeyUp = "OnKeyUp" // M-Add
     case OnKeyPress = "OnKeyPress"
+    case OnLocaleChange = "OnLocaleChange"
     case OnLanguageChange = "OnLanguageChange"
     case OnMemoryLoadHigh = "OnMemoryLoadHigh"
     case OnMemoryLoadLow = "OnMemoryLoadLow" // M-Add


### PR DESCRIPTION
## Summary
- add `OnLocaleChange` to the `EventID` enum

## Testing
- `swift build` *(fails: no such module 'Network')*

------
https://chatgpt.com/codex/tasks/task_e_68875007cce48322907801fdd45bdb59