### PR TITLE
Add close confirmation dialog

### DIFF
--- a/Ourin/CloseConfirmationDelegate.swift
+++ b/Ourin/CloseConfirmationDelegate.swift
@@ -1,0 +1,23 @@
+import AppKit
+
+class CloseConfirmationDelegate: NSObject, NSWindowDelegate {
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = "終了しますか?"
+        alert.informativeText = "アプリを終了するか最小化するか選択してください。"
+        alert.addButton(withTitle: "終了")
+        alert.addButton(withTitle: "最小化")
+        alert.addButton(withTitle: "キャンセル")
+        let response = alert.runModal()
+        switch response {
+        case .alertFirstButtonReturn:
+            NSApplication.shared.terminate(nil)
+            return false
+        case .alertSecondButtonReturn:
+            sender.miniaturize(nil)
+            return false
+        default:
+            return false
+        }
+    }
+}

--- a/Ourin/ContentView.swift
+++ b/Ourin/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
 
     @State private var selection: Section? = .general
     @State private var runningTask: Task<Void, Never>? = nil
+    @State private var closeDelegate: CloseConfirmationDelegate? = nil
 
     private let logger = Logger(subsystem: "jp.ourin.devtools", category: "ui")
 
@@ -59,6 +60,15 @@ struct ContentView: View {
                     }
                 }
         }
+        .background(
+            WindowAccessor { win in
+                if let win = win, closeDelegate == nil {
+                    let del = CloseConfirmationDelegate()
+                    win.delegate = del
+                    closeDelegate = del
+                }
+            }
+        )
         // 右クリックメニューはメニューバーに移動
 
     }

--- a/Ourin/WindowAccessor.swift
+++ b/Ourin/WindowAccessor.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+import AppKit
+
+struct WindowAccessor: NSViewRepresentable {
+    var callback: (NSWindow?) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { [weak view] in
+            callback(view?.window)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}


### PR DESCRIPTION
## Summary
- implement `CloseConfirmationDelegate` that asks to quit or minimize
- allow attaching a window delegate via `WindowAccessor`
- integrate confirmation alert in `ContentView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68874fcf0de483228db2c7b2440ec74d