### PR TITLE
Add DevTools window

### DIFF
--- a/Ourin/DevTools/DevToolsCommands.swift
+++ b/Ourin/DevTools/DevToolsCommands.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct DevToolsCommands: Commands {
+    @Environment(\.openWindow) private var openWindow
+    var body: some Commands {
+        CommandMenu("DevTools") {
+            Button("DevToolsを表示") {
+                openWindow(id: "DevTools")
+            }
+            .keyboardShortcut("d", modifiers: [.command, .option])
+        }
+    }
+}

--- a/Ourin/DevTools/DevToolsView.swift
+++ b/Ourin/DevTools/DevToolsView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import OSLog
+
+/// DevTools main view with sidebar and toolbar
+struct DevToolsView: View {
+    /// sidebar sections
+    enum Section: String, CaseIterable, Identifiable {
+        case general = "基本設定"
+        case shioriResource = "SHIORIリソース"
+        var id: String { rawValue }
+    }
+
+    @State private var selection: Section? = .general
+    private let logger = Logger(subsystem: "jp.ourin.devtools", category: "ui")
+
+    var body: some View {
+        NavigationSplitView {
+            List(Section.allCases, selection: $selection) { section in
+                Text(section.rawValue)
+            }
+            .listStyle(SidebarListStyle())
+            .frame(minWidth: 180)
+        } detail: {
+            detailView
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .toolbar {
+                    ToolbarItemGroup {
+                        Button(action: reload) {
+                            Image(systemName: "arrow.clockwise")
+                        }.help("再読込")
+                    }
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var detailView: some View {
+        switch selection {
+        case .general:
+            GeneralPane()
+        case .shioriResource:
+            ResourcePane()
+        case .none:
+            Text("セクションを選択")
+        }
+    }
+
+    private func reload() {
+        logger.info("DevTools reload triggered")
+        ResourceBridge.shared.invalidateAll()
+    }
+}
+
+#Preview {
+    DevToolsView()
+}

--- a/Ourin/DevTools/GeneralPane.swift
+++ b/Ourin/DevTools/GeneralPane.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import OSLog
+
+struct GeneralPane: View {
+    @State private var dataPath: String = ""
+    private let logger = Logger(subsystem: "jp.ourin.devtools", category: "settings")
+
+    var body: some View {
+        Form {
+            HStack {
+                TextField("データフォルダ", text: $dataPath)
+                Button("参照…") { browse() }
+            }
+            .onAppear(perform: load)
+        }
+        .padding()
+    }
+
+    private func load() {
+        if let url = try? OurinPaths.baseDirectory() {
+            dataPath = url.path
+        }
+    }
+
+    private func browse() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.begin { resp in
+            if resp == .OK, let url = panel.url {
+                dataPath = url.path
+                logger.info("data folder set: \(url.path, privacy: .public)")
+            }
+        }
+    }
+}
+
+#Preview {
+    GeneralPane()
+}

--- a/Ourin/DevTools/ResourcePane.swift
+++ b/Ourin/DevTools/ResourcePane.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct ResourcePane: View {
+    private struct Item: Identifiable {
+        let id = UUID()
+        let key: String
+        let value: String
+    }
+    @State private var items: [Item] = []
+
+    var body: some View {
+        VStack {
+            HStack {
+                Button("読み込み") { load() }
+                Spacer()
+            }
+            Table(items) {
+                TableColumn("キー") { Text($0.key) }
+                TableColumn("値") { Text($0.value) }
+            }
+        }
+        .padding()
+        .onAppear(perform: load)
+    }
+
+    private func load() {
+        items = ["sakura.name", "kero.name"].map { key in
+            Item(key: key, value: ResourceBridge.shared.get(key) ?? "")
+        }
+    }
+}
+
+#Preview {
+    ResourcePane()
+}

--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -13,9 +13,15 @@ struct OurinApp: App {
         WindowGroup {
             ContentView()
         }
+        WindowGroup("DevTools", id: "DevTools") {
+            DevToolsView()
+        }
         // The right-click menu has moved to the menu bar.
         MenuBarExtra("Ourin") {
             RightClickMenu()
+        }
+        Commands {
+            DevToolsCommands()
         }
     }
 }


### PR DESCRIPTION
## Summary
- create DevTools module with sidebar+toolbar window
- implement basic `General` and `SHIORI Resource` panes
- provide `DevTools` commands and window scene
- integrate DevTools window into `OurinApp`
- localize DevTools UI strings to Japanese

## Testing
- `swiftc -dump-ast Ourin/DevTools/DevToolsView.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_688794bd5584832293dd36d9077b29cc