### PR TITLE
Fix old macOS build issues

### DIFF
--- a/Ourin/DevTools/DevToolsCommands.swift
+++ b/Ourin/DevTools/DevToolsCommands.swift
@@ -4,17 +4,22 @@ import SwiftUI
 struct DevToolsCommands: Commands {
     var body: some Commands {
         CommandMenu("DevTools") {
-            Button("DevToolsを表示") {
-                if #available(macOS 13.0, *) {
-                    openWindow(id: "DevTools")
-                } else {
-                    (NSApp.delegate as? AppDelegate)?.showDevTools()
-                }
-            }
-            .keyboardShortcut("d", modifiers: [.command, .option])
+            Button("DevToolsを表示") { openDevTools() }
+                .keyboardShortcut("d", modifiers: [.command, .option])
         }
     }
 
-    @available(macOS 13.0, *)
+    private func openDevTools() {
+        if #available(macOS 13.0, *) {
+            openWindow(id: "DevTools")
+        } else {
+            (NSApp.delegate as? AppDelegate)?.showDevTools()
+        }
+    }
+
+    // `openWindow` is available from macOS 13.0. Keeping the property
+    // unconditionally defined lets the compiler resolve the symbol when
+    // building with a modern SDK while older macOS versions simply ignore it
+    // at runtime via the availability check in `openDevTools()`.
     @Environment(\.openWindow) private var openWindow
 }

--- a/Ourin/DevTools/DevToolsView.swift
+++ b/Ourin/DevTools/DevToolsView.swift
@@ -25,13 +25,7 @@ struct DevToolsView: View {
         } detail: {
             detailView
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .toolbar {
-                    ToolbarItemGroup {
-                        Button(action: reload) {
-                            Image(systemName: "arrow.clockwise")
-                        }.help("再読込")
-                    }
-                }
+                .applyToolbar(reload: reload)
         }
     }
 
@@ -53,6 +47,34 @@ struct DevToolsView: View {
     }
 }
 
+#if os(macOS)
+private struct ToolbarCompat: ViewModifier {
+    let action: () -> Void
+    func body(content: Content) -> some View {
+        if #available(macOS 11.0, *) {
+            content.toolbar {
+                ToolbarItemGroup {
+                    Button(action: action) {
+                        Image(systemName: "arrow.clockwise")
+                    }.help("再読込")
+                }
+            }
+        } else {
+            content
+        }
+    }
+}
+
+private extension View {
+    func applyToolbar(reload: @escaping () -> Void) -> some View {
+        modifier(ToolbarCompat(action: reload))
+    }
+}
+#else
+private extension View {
+    func applyToolbar(reload: @escaping () -> Void) -> some View { self }
+}
+#endif
 #Preview {
     DevToolsView()
 }

--- a/Ourin/DevTools/ResourcePane.swift
+++ b/Ourin/DevTools/ResourcePane.swift
@@ -14,10 +14,7 @@ struct ResourcePane: View {
                 Button("読み込み") { load() }
                 Spacer()
             }
-            Table(items) {
-                TableColumn("キー") { Text($0.key) }
-                TableColumn("値") { Text($0.value) }
-            }
+            tableView
         }
         .padding()
         .onAppear(perform: load)
@@ -26,6 +23,24 @@ struct ResourcePane: View {
     private func load() {
         items = ["sakura.name", "kero.name"].map { key in
             Item(key: key, value: ResourceBridge.shared.get(key) ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private var tableView: some View {
+        if #available(macOS 12.0, *) {
+            Table(items) {
+                TableColumn("キー") { Text($0.key) }
+                TableColumn("値") { Text($0.value) }
+            }
+        } else {
+            List(items) { item in
+                HStack {
+                    Text(item.key).frame(minWidth: 120, alignment: .leading)
+                    Spacer()
+                    Text(item.value)
+                }
+            }
         }
     }
 }

--- a/Ourin/ResourceBridge/ResourceBridge.swift
+++ b/Ourin/ResourceBridge/ResourceBridge.swift
@@ -9,7 +9,8 @@ private extension String.Encoding {
 
 /// SHIORI の Resource キーを取得してキャッシュするブリッジ。
 /// 仕様は `docs/PROPERTY_Resource_3.0M_SPEC.md` を参照。
-@available(macOS 11.0, *)
+/// ResourceBridge does not rely on modern APIs other than logging. Use
+/// `CompatLogger` so the class works on older macOS versions as well.
 public final class ResourceBridge {
     /// シングルトンインスタンス
     public static let shared = ResourceBridge()
@@ -24,7 +25,7 @@ public final class ResourceBridge {
     /// キャッシュ保持時間（秒）
     private let ttl: TimeInterval = 5
     /// ロガー
-    private let logger = Logger(subsystem: "Ourin", category: "ResourceBridge")
+    private let logger = CompatLogger(subsystem: "Ourin", category: "ResourceBridge")
 
     /// Get resource value for given key via SHIORI. Uses cache if valid.
     public func get(_ key: String) -> String? {


### PR DESCRIPTION
## Summary
- make DevToolsCommands open the window using a helper so the property isn't @available
- add OS version checks for the DevTools toolbar
- support macOS < 12 in ResourcePane by falling back to `List`
- remove @available from ResourceBridge and use CompatLogger

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6888bbbc92ac832294fa3b470d0d3d1c