### PR TITLE
Fix DevTools for older macOS versions

### DIFF
--- a/Ourin/DevTools/DevToolsCommands.swift
+++ b/Ourin/DevTools/DevToolsCommands.swift
@@ -21,5 +21,6 @@ struct DevToolsCommands: Commands {
     // unconditionally defined lets the compiler resolve the symbol when
     // building with a modern SDK while older macOS versions simply ignore it
     // at runtime via the availability check in `openDevTools()`.
+    @available(macOS 13.0, *)
     @Environment(\.openWindow) private var openWindow
 }

--- a/Ourin/DevTools/DevToolsCommands.swift
+++ b/Ourin/DevTools/DevToolsCommands.swift
@@ -10,17 +10,22 @@ struct DevToolsCommands: Commands {
     }
 
     private func openDevTools() {
+#if compiler(>=5.7)
         if #available(macOS 13.0, *) {
             openWindow(id: "DevTools")
         } else {
             (NSApp.delegate as? AppDelegate)?.showDevTools()
         }
+#else
+        (NSApp.delegate as? AppDelegate)?.showDevTools()
+#endif
     }
 
     // `openWindow` is available from macOS 13.0. Keeping the property
-    // unconditionally defined lets the compiler resolve the symbol when
-    // building with a modern SDK while older macOS versions simply ignore it
+    // unconditionally defined when compiling with a modern SDK lets the
+    // compiler resolve the symbol while older macOS versions simply ignore it
     // at runtime via the availability check in `openDevTools()`.
-    @available(macOS 13.0, *)
+#if compiler(>=5.7)
     @Environment(\.openWindow) private var openWindow
+#endif
 }

--- a/Ourin/DevTools/DevToolsView.swift
+++ b/Ourin/DevTools/DevToolsView.swift
@@ -16,16 +16,30 @@ struct DevToolsView: View {
     private let logger = CompatLogger(subsystem: "jp.ourin.devtools", category: "ui")
 
     var body: some View {
-        NavigationSplitView {
-            List(Section.allCases, selection: $selection) { section in
-                Text(section.rawValue)
+        if #available(macOS 13.0, *) {
+            NavigationSplitView {
+                List(Section.allCases, selection: $selection) { section in
+                    Text(section.rawValue)
+                }
+                .listStyle(SidebarListStyle())
+                .frame(minWidth: 180)
+            } detail: {
+                detailView
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .applyToolbar(reload: reload)
             }
-            .listStyle(SidebarListStyle())
-            .frame(minWidth: 180)
-        } detail: {
-            detailView
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .applyToolbar(reload: reload)
+        } else {
+            NavigationView {
+                List(Section.allCases, selection: $selection) { section in
+                    Text(section.rawValue)
+                }
+                .listStyle(SidebarListStyle())
+                .frame(minWidth: 180)
+
+                detailView
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .applyToolbar(reload: reload)
+            }
         }
     }
 

--- a/Ourin/DevTools/DevToolsView.swift
+++ b/Ourin/DevTools/DevToolsView.swift
@@ -16,6 +16,7 @@ struct DevToolsView: View {
     private let logger = CompatLogger(subsystem: "jp.ourin.devtools", category: "ui")
 
     var body: some View {
+#if compiler(>=5.7)
         if #available(macOS 13.0, *) {
             NavigationSplitView {
                 List(Section.allCases, selection: $selection) { section in
@@ -29,17 +30,24 @@ struct DevToolsView: View {
                     .applyToolbar(reload: reload)
             }
         } else {
-            NavigationView {
-                List(Section.allCases, selection: $selection) { section in
-                    Text(section.rawValue)
-                }
-                .listStyle(SidebarListStyle())
-                .frame(minWidth: 180)
+            navigationViewCompat
+        }
+#else
+        navigationViewCompat
+#endif
+    }
 
-                detailView
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .applyToolbar(reload: reload)
+    private var navigationViewCompat: some View {
+        NavigationView {
+            List(Section.allCases, selection: $selection) { section in
+                Text(section.rawValue)
             }
+            .listStyle(SidebarListStyle())
+            .frame(minWidth: 180)
+
+            detailView
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .applyToolbar(reload: reload)
         }
     }
 

--- a/Ourin/DevTools/ResourcePane.swift
+++ b/Ourin/DevTools/ResourcePane.swift
@@ -28,18 +28,26 @@ struct ResourcePane: View {
 
     @ViewBuilder
     private var tableView: some View {
+#if compiler(>=5.5)
         if #available(macOS 12.0, *) {
             Table(items) {
                 TableColumn("キー") { Text($0.key) }
                 TableColumn("値") { Text($0.value) }
             }
         } else {
-            List(items) { item in
-                HStack {
-                    Text(item.key).frame(minWidth: 120, alignment: .leading)
-                    Spacer()
-                    Text(item.value)
-                }
+            legacyList
+        }
+#else
+        legacyList
+#endif
+    }
+
+    private var legacyList: some View {
+        List(items) { item in
+            HStack {
+                Text(item.key).frame(minWidth: 120, alignment: .leading)
+                Spacer()
+                Text(item.value)
             }
         }
     }


### PR DESCRIPTION
## Summary
- add availability annotation around `openWindow` environment property
- provide `NavigationView` fallback when `NavigationSplitView` isn't available

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6888ceb0a2c483229a0e6c9007d59f81