### PR TITLE
Fix compile errors for macOS 10.15 build

### DIFF
--- a/Ourin/DevTools/DevToolsCommands.swift
+++ b/Ourin/DevTools/DevToolsCommands.swift
@@ -26,6 +26,7 @@ struct DevToolsCommands: Commands {
     // compiler resolve the symbol while older macOS versions simply ignore it
     // at runtime via the availability check in `openDevTools()`.
 #if compiler(>=5.7)
+    @available(macOS 13.0, *)
     @Environment(\.openWindow) private var openWindow
 #endif
 }

--- a/Ourin/RightClickMenu.swift
+++ b/Ourin/RightClickMenu.swift
@@ -5,6 +5,7 @@ import AppKit
 // メニュー構成例は docs/RightClickMenuMockup.md を参照。
 
 /// 右クリックメニュー UI の SwiftUI 実装
+@available(macOS 11.0, *)
 struct RightClickMenu: View {
     /// メニュー項目一覧を返す
     var body: some View {


### PR DESCRIPTION
## Summary
- add macOS availability annotation for `RightClickMenu`
- gate `openWindow` environment property behind macOS 13 check

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6889da19fce88322913d08d5f7223d74