### PR TITLE
Add bundled emily4.nar auto install

### DIFF
--- a/Ourin/ContentView.swift
+++ b/Ourin/ContentView.swift
@@ -114,31 +114,9 @@ struct ContentView: View {
     private func runTestScenario() {
         logger.info("run test scenario")
         stopScenario()
-        
-        // ゴーストウィンドウを表示
-        showGhostWindow()
-        
-        guard let dispatcher = (NSApp.delegate as? AppDelegate)?.pluginDispatcher else { return }
-        let windows = NSApplication.shared.windows
-        let path = Bundle.main.bundlePath
-        
-        runningTask = Task {
-            // まずテスト用のゴーストを起動してみる
-            await startTestGhost()
-            
-            // プラグインイベントを送信
-            dispatcher.onGhostBoot(windows: windows, ghostName: "TestGhost", shellName: "default", ghostID: "test", path: path)
-            try? await Task.sleep(nanoseconds: 2_000_000_000) // 2秒待機
-            
-            dispatcher.onMenuExec(windows: windows, ghostName: "TestGhost", shellName: "default", ghostID: "test", path: path)
-            try? await Task.sleep(nanoseconds: 2_000_000_000) // 2秒待機
-            
-            dispatcher.onGhostExit(windows: windows, ghostName: "TestGhost", shellName: "default", ghostID: "test", path: path)
-            
-            // ゴーストウィンドウを閉じる
-            await MainActor.run {
-                closeGhostWindow()
-            }
+
+        if let delegate = NSApp.delegate as? AppDelegate {
+            delegate.installDefaultGhost()
         }
     }
 

--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -105,6 +105,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Install bundled emily4.nar and run it if present
+    func installDefaultGhost() {
+        if let url = Bundle.main.url(forResource: "emily4", withExtension: "nar") {
+            installNar(at: url)
+        } else {
+            NSLog("Bundled emily4.nar not found")
+        }
+    }
+
     private func installNar(at url: URL) {
         do {
             let target = try narInstaller.install(fromNar: url)


### PR DESCRIPTION
## Summary
- provide `installDefaultGhost` to install and run bundled `emily4.nar`
- call `installDefaultGhost` when the Run Test button is pressed

## Testing
- `xcodebuild -project Ourin.xcodeproj -scheme Ourin build` *(fails: command not found)*
- `xcodebuild -project Ourin.xcodeproj -scheme Ourin test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c8b6a653c8322833bdf27cd877d5e