### PR TITLE
Fix DevTools UI list rendering

### DIFF
--- a/Ourin/DevTools/DevToolsView.swift
+++ b/Ourin/DevTools/DevToolsView.swift
@@ -20,13 +20,10 @@ struct DevToolsView: View {
 #if compiler(>=5.7)
         if #available(macOS 13.0, *) {
             NavigationSplitView {
-                List(Section.allCases, selection: $selection) { section in
-                    NavigationLink(
-                        destination: EmptyView(),
-                        tag: section,
-                        selection: $selection
-                    ) {
+                List(selection: $selection) {
+                    ForEach(Section.allCases) { section in
                         Text(section.rawValue)
+                            .tag(section)
                     }
                 }
                 .listStyle(SidebarListStyle())
@@ -46,13 +43,10 @@ struct DevToolsView: View {
 
     private var navigationViewCompat: some View {
         NavigationView {
-            List(Section.allCases, selection: $selection) { section in
-                NavigationLink(
-                    destination: EmptyView(),
-                    tag: section,
-                    selection: $selection
-                ) {
+            List(selection: $selection) {
+                ForEach(Section.allCases) { section in
                     Text(section.rawValue)
+                        .tag(section)
                 }
             }
             .listStyle(SidebarListStyle())


### PR DESCRIPTION
## Summary
- fix sidebar list binding in DevToolsView so detail panes show correctly

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c91ac6ef48322ad58751c9a52c53d