### PR TITLE
Fix test ghost window display

### DIFF
--- a/Ourin/ContentView.swift
+++ b/Ourin/ContentView.swift
@@ -115,6 +115,9 @@ struct ContentView: View {
         if let delegate = NSApp.delegate as? AppDelegate {
             delegate.installDefaultGhost()
         }
+
+        // Ensure the test ghost window is visible during the scenario
+        showGhostWindow()
     }
 
     private func stopScenario() {


### PR DESCRIPTION
## Summary
- show the test ghost window when running the test scenario

## Testing
- `xcodebuild -project Ourin.xcodeproj -scheme Ourin test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c98c64ff4832288bfd1e8462d8ac3