### PR TITLE
Keep Emily4 running during test scenarios

### DIFF
--- a/Ourin/DevTools/DevToolsCommands.swift
+++ b/Ourin/DevTools/DevToolsCommands.swift
@@ -94,14 +94,17 @@ struct DevToolsCommands: Commands {
             dispatcher.onGhostBoot(windows: windows, ghostName: "emily4", shellName: "default", ghostID: "emily4", path: path)
             try? await Task.sleep(nanoseconds: 500_000_000)
             dispatcher.onMenuExec(windows: windows, ghostName: "emily4", shellName: "default", ghostID: "emily4", path: path)
-            try? await Task.sleep(nanoseconds: 500_000_000)
-            dispatcher.onGhostExit(windows: windows, ghostName: "emily4", shellName: "default", ghostID: "emily4", path: path)
         }
-        
+
         NotificationCenter.default.post(name: .testScenarioStarted, object: nil)
     }
-    
+
     private func stopTestScenario() {
+        if let dispatcher = (NSApp.delegate as? AppDelegate)?.pluginDispatcher {
+            let windows = NSApplication.shared.windows
+            let path = Bundle.main.bundlePath
+            dispatcher.onGhostExit(windows: windows, ghostName: "emily4", shellName: "default", ghostID: "emily4", path: path)
+        }
         NotificationCenter.default.post(name: .testScenarioStopped, object: nil)
     }
     


### PR DESCRIPTION
## Summary
- prevent immediate ghost exit in test scenarios
- stop test scenario now sends OnGhostExit only when explicitly requested

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e25764ed483228922e4bf32926b51