### PR TITLE
I have addressed a build-stopping error and a warning in your Xcode p…

### DIFF
--- a/Ourin/DevTools/DevToolsCommands.swift
+++ b/Ourin/DevTools/DevToolsCommands.swift
@@ -2,17 +2,10 @@ import SwiftUI
 
 @available(macOS 11.0, *)
 struct DevToolsCommands: Commands {
-#if compiler(>=5.7)
-    @Environment(\.openWindow) private var openWindow
-#endif
-
     var body: some Commands {
         // View メニューにDevTools項目を追加
         CommandMenu("View") {
-            Button("DevTools を表示") {
-                openDevTools()
-            }
-            .keyboardShortcut("d", modifiers: [.command])
+            OpenDevToolsProxy()
         }
         
         // Debug メニューを追加
@@ -65,18 +58,6 @@ struct DevToolsCommands: Commands {
                 openPluginGuide()
             }
         }
-    }
-
-    private func openDevTools() {
-#if compiler(>=5.7)
-        if #available(macOS 13.0, *) {
-            openWindow(id: "DevTools")
-        } else {
-            (NSApp.delegate as? AppDelegate)?.showDevTools()
-        }
-#else
-        (NSApp.delegate as? AppDelegate)?.showDevTools()
-#endif
     }
     
     private func reloadDevTools() {
@@ -151,5 +132,36 @@ struct DevToolsCommands: Commands {
         if let url = URL(string: "https://github.com/eightman999/Ourin/wiki/Plugin-Development") {
             NSWorkspace.shared.open(url)
         }
+    }
+}
+
+struct OpenDevToolsProxy: Commands {
+    var body: some Commands {
+        if #available(macOS 13.0, *) {
+            ModernDevToolsButton()
+        } else {
+            LegacyDevToolsButton()
+        }
+    }
+}
+
+@available(macOS 13.0, *)
+struct ModernDevToolsButton: Commands {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some Commands {
+        Button("DevTools を表示") {
+            openWindow(id: "DevTools")
+        }
+        .keyboardShortcut("d", modifiers: [.command])
+    }
+}
+
+struct LegacyDevToolsButton: Commands {
+    var body: some Commands {
+        Button("DevTools を表示") {
+            (NSApp.delegate as? AppDelegate)?.showDevTools()
+        }
+        .keyboardShortcut("d", modifiers: [.command])
     }
 }

--- a/Ourin/Resources/Info.plist
+++ b/Ourin/Resources/Info.plist
@@ -6,7 +6,7 @@
     <key>CFBundleIdentifier</key><string>furin-lab.Ourin</string>
     <key>CFBundleVersion</key><string>1</string>
     <key>CFBundleShortVersionString</key><string>1.0</string>
-    <key>LSMinimumSystemVersion</key><string>10.15</string>
+    <key>LSMinimumSystemVersion</key><string>11.0</string>
     <key>CFBundleURLTypes</key>
     <array>
         <dict>


### PR DESCRIPTION
…roject.

- I fixed a compile error in `DevToolsCommands.swift` related to the use of the `openWindow` API, which is only available on macOS 13.0+. I refactored the code to conditionally use the new API on supported systems while maintaining compatibility with older macOS versions. I did this by isolating the new API call into a separate `Commands` struct that is only used on macOS 13.0+.

- I updated `LSMinimumSystemVersion` in `Info.plist` from `10.15` to `11.0` to match the `MACOSX_DEPLOYMENT_TARGET` in your project settings. This resolved a warning during the build process.

I have not addressed the warning about the `Info.plist` file being included in the "Copy Bundle Resources" phase, as it requires complex manual modification of the `.pbxproj` file and is best fixed within the Xcode IDE. This warning does not prevent the project from building.