### PR TITLE
Fix: Emily4 ghost fails to start

### DIFF
--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -77,6 +77,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let ext = OurinExternalServer()
         ext.start()
         externalServer = ext
+
+        // デフォルトゴーストをインストール・実行
+        self.installDefaultGhost()
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -141,8 +144,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 NSApp.presentAlert(style: .informational, title: "OnBoot", text: script)
             }
         }
-        adapter.unload()
-        yayaAdapter = nil
     }
 
     /// Show DevTools window on macOS < 13


### PR DESCRIPTION
The emily4 ghost was not starting because the YAYA adapter process was being terminated immediately after the ghost was loaded.

This was caused by two issues in `AppDelegate.swift`:
1. The `runGhost(at:)` method called `adapter.unload()` right after loading the ghost, which terminates the ghost's process.
2. The `installDefaultGhost()` method, which loads the bundled emily4.nar, was never called.

This commit fixes the issue by:
- Removing the `adapter.unload()` and `yayaAdapter = nil` calls from `runGhost(at:)` to ensure the ghost process remains active.
- Calling `installDefaultGhost()` in `applicationDidFinishLaunching(_:)` to ensure the default ghost is loaded on application startup.

Note: I was unable to run the Xcode tests (`OurinTests`, `OurinUITests`) because the `xcodebuild` command is not available to me. The changes are a direct fix for a clear logical error and are expected to be safe.