### PR TITLE
I've fixed an issue to ensure test scenario events reach the SHIORI e…

### DIFF
--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -38,7 +38,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var pluginDispatcher: PluginEventDispatcher?
     /// NAR インストーラ
     private let narInstaller = NarInstaller()
-    private var yayaAdapter: YayaAdapter?
+    var yayaAdapter: YayaAdapter?
     /// DevTools window for legacy macOS
     private var devToolsWindow: NSWindow?
 


### PR DESCRIPTION
…ngine.

The "Run Test Scenario" command was only sending events to plugins, not to the ghost's SHIORI engine. This caused the scenario to do nothing.

I modified `DevToolsCommands.swift` to retrieve the active `YayaAdapter` and send `OnGhostBoot` and `OnMenuExec` events to it directly. To do this, I made the `yayaAdapter` property in `AppDelegate` accessible.

Additionally, to address log spam during debugging, I updated `TimerEmitter.swift` to suppress `OnIdle` and `OnSecondChange` events while a test scenario is active.