### PR TITLE
Devtoolのデバッグメニューからemily4を起動する機能を削除し、ContentViewのツールバーにあるスタートボタンから起動する…

### DIFF
--- a/Ourin/ContentView.swift
+++ b/Ourin/ContentView.swift
@@ -49,8 +49,7 @@ struct ContentView: View {
         }
         .modifier(ToolbarModifierIfAvailable(
             reload: reload,
-            runTest: runTestScenario,
-            stop: stopScenario,
+            start: startDefaultGhost,
             export: exportDiagnostics
         ))
         .background(
@@ -64,12 +63,6 @@ struct ContentView: View {
         )
         .onReceive(NotificationCenter.default.publisher(for: .devToolsReload)) { _ in
             reload()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .testScenarioStarted)) { _ in
-            runTestScenario()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .testScenarioStopped)) { _ in
-            stopScenario()
         }
     }
 
@@ -106,21 +99,12 @@ struct ContentView: View {
         }
     }
 
-    private func runTestScenario() {
-        logger.info("run test scenario")
-        stopScenario()
-
+    private func startDefaultGhost() {
+        logger.info("start default ghost")
         if let delegate = NSApp.delegate as? AppDelegate {
             delegate.installDefaultGhost()
         }
     }
-
-    private func stopScenario() {
-        logger.info("stop scenario")
-        runningTask?.cancel()
-        runningTask = nil
-    }
-    
 
     private func exportDiagnostics() {
         logger.info("export diagnostics")
@@ -135,8 +119,7 @@ struct ContentView: View {
 // MARK: - Conditional toolbar modifier for macOS 11.0+
 private struct ToolbarModifierIfAvailable: ViewModifier {
     var reload: () -> Void
-    var runTest: () -> Void
-    var stop: () -> Void
+    var start: () -> Void
     var export: () -> Void
 
     @ViewBuilder
@@ -147,13 +130,9 @@ private struct ToolbarModifierIfAvailable: ViewModifier {
                     Image(systemName: "arrow.clockwise")
                 }.help(Text("Reload"))
 
-                Button(action: runTest) {
+                Button(action: start) {
                     Image(systemName: "play.fill")
-                }.help(Text("Run Test"))
-
-                Button(action: stop) {
-                    Image(systemName: "stop.fill")
-                }.help(Text("Stop"))
+                }.help(Text("Start"))
 
                 Button(action: export) {
                     Image(systemName: "square.and.arrow.up")

--- a/Ourin/DevTools/DevToolsCommands.swift
+++ b/Ourin/DevTools/DevToolsCommands.swift
@@ -20,17 +20,6 @@ struct ModernDevToolsCommands: Commands {
             }
             .keyboardShortcut("r", modifiers: [.command])
             
-            Button("テストシナリオ実行") {
-                runTestScenario()
-            }
-            .keyboardShortcut("t", modifiers: [.command])
-            
-            Button("テストシナリオ停止") {
-                stopTestScenario()
-            }
-            .keyboardShortcut("t", modifiers: [.command, .shift])
-            
-            Divider()
             
             Button("診断情報をエクスポート") {
                 exportDiagnostics()
@@ -79,48 +68,6 @@ struct ModernDevToolsCommands: Commands {
         NotificationCenter.default.post(name: .devToolsReload, object: nil)
     }
     
-    private func runTestScenario() {
-        guard let appDelegate = NSApp.delegate as? AppDelegate,
-              let dispatcher = appDelegate.pluginDispatcher else { return }
-        let windows = NSApplication.shared.windows
-        let path = Bundle.main.bundlePath
-        
-        // SHIORIイベントを構築
-        let ghostName = "emily4"
-        let shellName = "default"
-        let ghostID = "emily4"
-        let pathPosix = PathNormalizer.posix(path)
-        let windowID = WindowIDMapper.ids(for: windows)
-        let bootRefs = [windowID, ghostName, shellName, ghostID, pathPosix]
-        let menuRefs = [windowID, ghostName, shellName, ghostID, pathPosix]
-
-        Task {
-            // プラグインへ通知
-            dispatcher.onGhostBoot(windows: windows, ghostName: ghostName, shellName: shellName, ghostID: ghostID, path: path)
-
-            // ゴーストへ通知
-            _ = appDelegate.yayaAdapter?.request(method: "NOTIFY", id: "OnGhostBoot", refs: bootRefs)
-
-            try? await Task.sleep(nanoseconds: 500_000_000)
-
-            // プラグインへ通知
-            dispatcher.onMenuExec(windows: windows, ghostName: ghostName, shellName: shellName, ghostID: ghostID, path: path)
-
-            // ゴーストへ通知
-            _ = appDelegate.yayaAdapter?.request(method: "GET", id: "OnMenuExec", refs: menuRefs)
-        }
-
-        NotificationCenter.default.post(name: .testScenarioStarted, object: nil)
-    }
-
-    private func stopTestScenario() {
-        if let dispatcher = (NSApp.delegate as? AppDelegate)?.pluginDispatcher {
-            let windows = NSApplication.shared.windows
-            let path = Bundle.main.bundlePath
-            dispatcher.onGhostExit(windows: windows, ghostName: "emily4", shellName: "default", ghostID: "emily4", path: path)
-        }
-        NotificationCenter.default.post(name: .testScenarioStopped, object: nil)
-    }
     
     private func exportDiagnostics() {
         let format = NSLocalizedString("診断情報は %@ にエクスポートされました", comment: "Diagnostics export message")

--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -163,8 +163,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
 extension Notification.Name {
     static let devToolsReload = Notification.Name("devToolsReload")
-    static let testScenarioStarted = Notification.Name("testScenarioStarted")
-    static let testScenarioStopped = Notification.Name("testScenarioStopped")
 }
 
 private extension NSApplication {


### PR DESCRIPTION
…ように統一しました。

変更点：
- `Ourin/DevTools/DevToolsCommands.swift` からテストシナリオ実行関連のコードを削除。
- `Ourin/ContentView.swift` のツールバーボタンを「Start」に明確化し、不要なコード（Stopボタン、通知ハンドラ）を削除。
- `Ourin/OurinApp.swift` から不要になった通知定義を削除。