### PR TITLE
feat: Update NAR install view and add log export

### DIFF
--- a/Ourin/LogModels.swift
+++ b/Ourin/LogModels.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+// MARK: - Log Data Models
+
+struct LogEntry: Identifiable {
+    let id = UUID()
+    let timestamp: Date
+    let level: String
+    let category: String
+    let message: String
+    let metadata: String
+}
+
+struct SignpostEntry: Identifiable {
+    let id = UUID()
+    let name: String
+    let type: SignpostType
+    let duration: Double
+}
+
+enum SignpostType {
+    case interval
+    case instant
+}

--- a/Ourin/LogStore.swift
+++ b/Ourin/LogStore.swift
@@ -1,0 +1,74 @@
+import Foundation
+import OSLog
+
+@available(macOS 11.0, *)
+class LogStore {
+    private let logger = CompatLogger(subsystem: "jp.ourin.logstore", category: "main")
+
+    func fetchLogEntries(subsystem: String, category: String, level: OSLogEntryLog.Level, since: Date) -> [LogEntry] {
+        var entries: [LogEntry] = []
+
+        do {
+            let store = try OSLogStore(scope: .currentProcessIdentifier)
+            let position = store.position(date: since)
+
+            // NSPredicate is tricky. We'll build it carefully.
+            var predicates: [NSPredicate] = []
+            if !subsystem.isEmpty && subsystem != "jp.ourin.*" {
+                predicates.append(NSPredicate(format: "subsystem == %@", subsystem))
+            }
+            if !category.isEmpty {
+                predicates.append(NSPredicate(format: "category == %@", category))
+            }
+
+            let compoundPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+
+            let logEntries = try store.getEntries(with: [], at: position, matching: compoundPredicate)
+                .compactMap { $0 as? OSLogEntryLog }
+                .filter { $0.level.rawValue >= level.rawValue }
+
+            entries = logEntries.map { log in
+                LogEntry(
+                    timestamp: log.date,
+                    level: levelToString(log.level),
+                    category: log.category,
+                    message: log.composedMessage,
+                    metadata: "" // OSLogEntry doesn't directly expose metadata in a simple string format
+                )
+            }
+            logger.info("Fetched \(entries.count) log entries.")
+
+        } catch {
+            logger.error("Failed to fetch log entries: \(error.localizedDescription)")
+        }
+
+        return entries
+    }
+
+    private func levelToString(_ level: OSLogEntryLog.Level) -> String {
+        switch level {
+        case .undefined: return "undefined"
+        case .debug: return "debug"
+        case .info: return "info"
+        case .notice: return "notice"
+        case .error: return "error"
+        case .fault:
+            return "fault"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}
+
+extension OSLogEntryLog.Level {
+    static func fromString(_ string: String) -> OSLogEntryLog.Level {
+        switch string.lowercased() {
+        case "debug": return .debug
+        case "info": return .info
+        case "notice": return .notice
+        case "error": return .error
+        case "fault": return .fault
+        default: return .undefined // "all"
+        }
+    }
+}


### PR DESCRIPTION
- The NAR installation screen now scans the actual installation directory to show a list of installed ghosts, removing the placeholder sample data.
- Implemented a parser for `descript.txt` to extract ghost names.
- Added a log export feature to the diagnostics screen.
- The logging view now displays live log data from the system's log store instead of mock data.
- Refactored log-related data models into a separate file for better organization.