### PR TITLE
Fix: Resolve multiple runtime and build issues

### DIFF
--- a/Ourin/CompatLogger.swift
+++ b/Ourin/CompatLogger.swift
@@ -41,6 +41,14 @@ struct CompatLogger {
         }
     }
 
+    func error(_ message: String) {
+        if #available(macOS 11.0, *), let log = modern as? Logger {
+            log.error("\(message)")
+        } else {
+            os_log("%{public}@", log: oslog, type: .error, message)
+        }
+    }
+
     func fault(_ message: String) {
         if #available(macOS 11.0, *), let log = modern as? Logger {
             log.fault("\(message)")

--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -118,16 +118,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func installNar(at url: URL) {
-        do {
-            let target = try narInstaller.install(fromNar: url)
-            NSApp.presentAlert(style: .informational,
-                               title: "Installed",
-                               text: "Installed: \(url.lastPathComponent)")
-            runGhost(at: target)
-        } catch {
-            NSApp.presentAlert(style: .critical,
-                               title: "Install failed",
-                               text: String(describing: error))
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let target = try self.narInstaller.install(fromNar: url)
+                DispatchQueue.main.async {
+                    NSApp.presentAlert(style: .informational,
+                                       title: "Installed",
+                                       text: "Installed: \(url.lastPathComponent)")
+                    self.runGhost(at: target)
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    NSApp.presentAlert(style: .critical,
+                                       title: "Install failed",
+                                       text: String(describing: error))
+                }
+            }
         }
     }
 

--- a/Ourin/USL/ShioriLoader.swift
+++ b/Ourin/USL/ShioriLoader.swift
@@ -39,7 +39,7 @@ final class YayaBackend: ShioriBackend {
         }
 
         guard let adapter = YayaAdapter() else {
-            //NSLog("[Ourin.YayaBackend] Failed to initialize YayaAdapter (is yaya_core missing?)")
+            NSLog("[Ourin.YayaBackend] Failed to initialize YayaAdapter (is yaya_core missing?)")
             return nil
         }
 


### PR DESCRIPTION
This commit addresses three separate issues:

1.  **Fix(CompatLogger): Add missing `error` method** A compile error `Value of type 'CompatLogger' has no member 'error'` occurred in `ContentView.swift`. This was because the `CompatLogger` struct was missing an `error` logging method. An `error` method has been added, mirroring the implementation of the other log levels.

2.  **Fix(NarInstall): Ensure installation feedback is always shown** When a `.nar` file was dragged and dropped, no UI feedback was shown. This was likely due to UI code (NSAlert) being called from a background thread. I've refactored the installation logic in `AppDelegate` to run on a background thread, with all UI alert calls dispatched back to the main thread. This ensures you are always notified of success or failure.

3.  **Refactor(YAYA): Improve logging for missing dependency** YAYA-based ghosts failed to start because of a missing `yaya_core` executable. While the missing file cannot be added, a commented-out `NSLog` message that explicitly mentioned this issue has been uncommented. This will make diagnosing this dependency issue easier in the future.