### PR TITLE
Refactor NAR handling and implement startup ghost selection

### DIFF
--- a/Ourin/DevTools/NarListPane.swift
+++ b/Ourin/DevTools/NarListPane.swift
@@ -24,18 +24,11 @@ struct NarListPane: View {
 
     private func load() {
         items.removeAll()
-        guard let base = try? OurinPaths.baseDirectory() else { return }
-        let fm = FileManager.default
         let kinds = ["ghost", "balloon", "shell", "plugin", "package"]
         for kind in kinds {
-            let dir = base.appendingPathComponent(kind, isDirectory: true)
-            guard let children = try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]) else { continue }
-            for child in children {
-                var isDir: ObjCBool = false
-                if fm.fileExists(atPath: child.path, isDirectory: &isDir), isDir.boolValue {
-                    items.append(Item(type: kind, name: child.lastPathComponent, path: child.path))
-                }
-            }
+            let packages = NarRegistry.shared.installedItems(ofType: kind)
+            let newItems = packages.map { Item(type: $0.type, name: $0.name, path: $0.path.path) }
+            items.append(contentsOf: newItems)
         }
     }
 

--- a/Ourin/Nar/NarRegistry.swift
+++ b/Ourin/Nar/NarRegistry.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// A structure to represent a found NAR package component.
+struct NarPackageItem: Identifiable, Hashable {
+    let id = UUID()
+    let type: String
+    let name: String
+    let path: URL
+}
+
+/// Discovers installed NAR packages (ghosts, balloons, etc.) from the file system.
+class NarRegistry {
+    /// A shared singleton instance for easy access.
+    static let shared = NarRegistry()
+
+    private let fileManager = FileManager.default
+
+    /// Returns the base directory where NAR packages are installed.
+    /// - Throws: An error if the base directory cannot be determined.
+    /// - Returns: The URL of the base directory.
+    func baseDirectory() throws -> URL {
+        return try OurinPaths.baseDirectory()
+    }
+
+    /// Fetches all installed items of a specific type (e.g., "ghost", "balloon").
+    /// - Parameter type: The category of package to look for.
+    /// - Returns: An array of `NarPackageItem` for the given type.
+    func installedItems(ofType type: String) -> [NarPackageItem] {
+        guard let base = try? baseDirectory() else {
+            return []
+        }
+
+        let directory = base.appendingPathComponent(type, isDirectory: true)
+        guard let children = try? fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]) else {
+            return []
+        }
+
+        var items: [NarPackageItem] = []
+        for childURL in children {
+            var isDirectory: ObjCBool = false
+            if fileManager.fileExists(atPath: childURL.path, isDirectory: &isDirectory), isDirectory.boolValue {
+                items.append(NarPackageItem(type: type, name: childURL.lastPathComponent, path: childURL))
+            }
+        }
+        return items
+    }
+
+    /// A convenience method to get the names of all installed ghosts.
+    /// - Returns: An array of strings containing the names of the ghosts.
+    func installedGhosts() -> [String] {
+        return installedItems(ofType: "ghost").map { $0.name }
+    }
+
+    /// A convenience method to get the names of all installed shells for a given ghost.
+    /// - Parameter ghostName: The name of the ghost to look for shells in.
+    /// - Returns: An array of strings containing the names of the shells.
+    func installedShells(for ghostName: String) -> [String] {
+        // Assuming shells are installed within a ghost's directory structure, which might be incorrect.
+        // For now, let's assume a global shell directory.
+        return installedItems(ofType: "shell").map { $0.name }
+    }
+
+    /// A convenience method to get the names of all installed balloons.
+    /// - Returns: An array of strings containing the names of the balloons.
+    func installedBalloons() -> [String] {
+        return installedItems(ofType: "balloon").map { $0.name }
+    }
+}

--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -78,8 +78,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         ext.start()
         externalServer = ext
 
-        // デフォルトゴーストをインストール・実行
-        self.installDefaultGhost()
+        // ユーザーが選択したゴースト、またはデフォルトのゴーストを起動
+        let startupGhostKey = "OurinStartupGhost"
+        if let ghostName = UserDefaults.standard.string(forKey: startupGhostKey), !ghostName.isEmpty {
+            self.runNamedGhost(name: ghostName)
+        } else {
+            self.installDefaultGhost()
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -115,6 +120,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             NSLog("Bundled emily4.nar not found")
         }
+    }
+
+    func runNamedGhost(name: String) {
+        guard let ghost = NarRegistry.shared.installedItems(ofType: "ghost").first(where: { $0.name == name }) else {
+            NSLog("Could not find ghost named \(name)")
+            DispatchQueue.main.async {
+                NSApp.presentAlert(style: .critical,
+                                   title: "Ghost not found",
+                                   text: "The ghost '\(name)' could not be found. It may have been moved or deleted.")
+            }
+            return
+        }
+        runGhost(at: ghost.path)
     }
 
     private func installNar(at url: URL) {


### PR DESCRIPTION
This commit addresses several issues related to NAR package handling and application startup.

- Centralized NAR package discovery by creating a new `NarRegistry` class. This provides a single source of truth for installed ghosts, balloons, and other packages, removing duplicated file system scanning logic.

- Refactored `NarListPane` in the DevTools to use the new `NarRegistry`, simplifying its implementation.

- Removed hardcoded shell and balloon lists in the `HeadlineBalloonView`. The view now dynamically loads the list of available packages from the `NarRegistry`, ensuring the UI reflects the actual installed components.

- Implemented a startup ghost selection feature in the `GeneralSettingsView`. You can now select your preferred ghost to launch from a dropdown menu. This setting is persisted in `UserDefaults`.

- Modified the application's startup logic in `AppDelegate` and the start button's action in `ContentView`. The application now launches your selected ghost on startup and when the start button is pressed, with a fallback to the default ghost if no selection is made.