### PR TITLE
feat: Implement ghost rendering pipeline

### DIFF
--- a/Ourin/Ghost/BalloonView.swift
+++ b/Ourin/Ghost/BalloonView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// A view that displays the ghost's dialogue in a balloon.
+struct BalloonView: View {
+    /// The ViewModel that provides the balloon text.
+    @StateObject var viewModel: BalloonViewModel
+
+    var body: some View {
+        if !viewModel.text.isEmpty {
+            Text(viewModel.text)
+                .padding()
+                .background(Color(NSColor.textBackgroundColor))
+                .cornerRadius(10)
+                .shadow(radius: 3)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Color.primary.opacity(0.2), lineWidth: 1)
+                )
+                .padding() // Padding to ensure shadow is not clipped
+        } else {
+            // If there is no text, the view should not be visible.
+            EmptyView()
+        }
+    }
+}
+
+#if DEBUG
+struct BalloonView_Previews: PreviewProvider {
+    static var previews: some View {
+        let vmWithText = BalloonViewModel()
+        vmWithText.text = "こんにちは、世界！\nThis is a sample balloon message."
+
+        let vmEmpty = BalloonViewModel()
+
+        return VStack {
+            BalloonView(viewModel: vmWithText)
+                .frame(width: 300)
+            BalloonView(viewModel: vmEmpty)
+        }
+        .padding()
+    }
+}
+#endif

--- a/Ourin/Ghost/CharacterView.swift
+++ b/Ourin/Ghost/CharacterView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// A view that displays the character's shell image.
+struct CharacterView: View {
+    /// The ViewModel that provides the character image.
+    @StateObject var viewModel: CharacterViewModel
+
+    var body: some View {
+        if let image = viewModel.image {
+            Image(nsImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+        } else {
+            // The view is transparent and shows nothing if there is no image.
+            EmptyView()
+        }
+    }
+}
+
+#if DEBUG
+struct CharacterView_Previews: PreviewProvider {
+    static var previews: some View {
+        let vm = CharacterViewModel()
+        // To preview, you would need to load a sample image.
+        // For example, from the app's asset catalog or a file path.
+        // vm.image = NSImage(named: "someSampleImage")
+
+        return CharacterView(viewModel: vm)
+            .frame(width: 200, height: 300)
+            .background(Color.gray.opacity(0.3))
+    }
+}
+#endif

--- a/Ourin/Ghost/GhostManager.swift
+++ b/Ourin/Ghost/GhostManager.swift
@@ -1,0 +1,202 @@
+import SwiftUI
+import AppKit
+
+// MARK: - ViewModels
+
+/// ViewModel for the character view.
+class CharacterViewModel: ObservableObject {
+    @Published var image: NSImage?
+}
+
+/// ViewModel for the balloon view.
+class BalloonViewModel: ObservableObject {
+    @Published var text: String = ""
+}
+
+
+// MARK: - GhostManager
+
+/// Manages the lifecycle and display of a single ghost.
+class GhostManager: NSObject, SakuraScriptEngineDelegate {
+
+    // MARK: - Properties
+
+    private let ghostURL: URL
+    private var yayaAdapter: YayaAdapter?
+    private let sakuraEngine = SakuraScriptEngine()
+
+    // Window management
+    private var characterWindow: NSWindow?
+    private var balloonWindow: NSWindow?
+
+    // ViewModels
+    private let characterViewModel = CharacterViewModel()
+    private let balloonViewModel = BalloonViewModel()
+
+    private var currentScope: Int = 0
+
+    // MARK: - Initialization
+
+    init(ghostURL: URL) {
+        self.ghostURL = ghostURL
+        super.init()
+        self.sakuraEngine.delegate = self
+    }
+
+    deinit {
+        shutdown()
+    }
+
+    // MARK: - Public API
+
+    func start() {
+        setupWindows()
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let ghostRoot = self.ghostURL.appendingPathComponent("ghost/master", isDirectory: true)
+            let fm = FileManager.default
+
+            guard let contents = try? fm.contentsOfDirectory(at: ghostRoot, includingPropertiesForKeys: nil) else {
+                print("Failed to read contents of \(ghostRoot.path)")
+                return
+            }
+
+            let dics = contents.filter { $0.pathExtension.lowercased() == "dic" }.map { $0.lastPathComponent }
+
+            guard let adapter = YayaAdapter() else {
+                print("Failed to initialize YayaAdapter.")
+                return
+            }
+
+            self.yayaAdapter = adapter
+
+            guard adapter.load(ghostRoot: ghostRoot, dics: dics) else {
+                print("Failed to load ghost with Yaya.")
+                return
+            }
+
+            if let res = adapter.request(method: "GET", id: "OnBoot"), res.ok, let script = res.value {
+                DispatchQueue.main.async {
+                    self.runScript(script)
+                }
+            } else {
+                print("OnBoot script request failed or returned no script.")
+                // Even if OnBoot fails, we might want to show a default surface.
+                DispatchQueue.main.async {
+                    self.updateSurface(id: 0)
+                }
+            }
+        }
+    }
+
+    func shutdown() {
+        characterWindow?.orderOut(nil)
+        balloonWindow?.orderOut(nil)
+        characterWindow = nil
+        balloonWindow = nil
+        yayaAdapter?.unload()
+        yayaAdapter = nil
+    }
+
+    // MARK: - Window Setup
+
+    private func setupWindows() {
+        // Create Character Window
+        let characterView = CharacterView(viewModel: characterViewModel)
+        let hostingController = NSHostingController(rootView: characterView)
+
+        let window = NSWindow(contentViewController: hostingController)
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.styleMask = [.borderless]
+        window.ignoresMouseEvents = true // Click-through
+        window.level = .normal
+        window.setFrame(.init(x: 200, y: 200, width: 300, height: 400), display: true)
+        window.makeKeyAndOrderFront(nil)
+        self.characterWindow = window
+
+        // Create Balloon Window
+        let balloonView = BalloonView(viewModel: balloonViewModel)
+        let balloonHostingController = NSHostingController(rootView: balloonView)
+
+        let bWindow = NSWindow(contentViewController: balloonHostingController)
+        bWindow.isOpaque = false
+        bWindow.backgroundColor = .clear
+        bWindow.styleMask = [.borderless]
+        bWindow.hasShadow = false
+        bWindow.level = .normal
+        bWindow.setFrame(.init(x: 450, y: 300, width: 250, height: 200), display: true)
+        bWindow.makeKeyAndOrderFront(nil)
+        self.balloonWindow = bWindow
+    }
+
+    // MARK: - Scripting
+
+    func runScript(_ script: String) {
+        // Reset balloon text for new script
+        balloonViewModel.text = ""
+        sakuraEngine.run(script: script)
+    }
+
+    // MARK: - SakuraScriptEngineDelegate
+
+    func sakuraEngine(_ engine: SakuraScriptEngine, didEmit token: SakuraScriptEngine.Token) {
+        switch token {
+        case .scope(let id):
+            currentScope = id
+            print("Switched to scope \(id)")
+
+        case .surface(let id):
+            updateSurface(id: id)
+
+        case .text(let text):
+            balloonViewModel.text += text
+
+        case .newline:
+            balloonViewModel.text += "\n"
+
+        case .end:
+            // The view updates automatically. We could do cleanup here if needed.
+            print("Script end. Final text: \(balloonViewModel.text)")
+
+        case .animation, .command:
+            // TODO: Handle other tokens
+            print("Received unhandled token: \(token)")
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func updateSurface(id: Int) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let image = self.loadImage(surfaceId: id)
+            DispatchQueue.main.async {
+                self.characterViewModel.image = image
+                if let image = image {
+                    // Resize window to fit the new surface
+                    self.characterWindow?.setContentSize(image.size)
+                }
+            }
+        }
+    }
+
+    private func loadImage(surfaceId: Int) -> NSImage? {
+        // In Ukagaka, scope 1 (u) surfaces are often prefixed with '1'
+        // e.g., \u\s[10] -> surface1010.png
+        let surfacePrefix = currentScope == 1 ? "1" : ""
+
+        let shellURL = ghostURL.appendingPathComponent("shell/master")
+        // TODO: This needs to handle shell.txt for surface definitions properly.
+        // This is a simplified loader for now.
+        let surfaceFilename = String(format: "surface%@%d.png", surfacePrefix, surfaceId)
+        let imageURL = shellURL.appendingPathComponent(surfaceFilename)
+
+        print("Loading image: \(imageURL.path)")
+        guard FileManager.default.fileExists(atPath: imageURL.path) else {
+            print("Image not found at path: \(imageURL.path)")
+            return nil
+        }
+
+        return NSImage(contentsOf: imageURL)
+    }
+}


### PR DESCRIPTION
Implements a new rendering pipeline to display Ukagaka ghosts. The original application was missing the UI components to render the character shell and balloon text.

This change introduces a GhostManager class responsible for:
- Creating and managing transparent windows for the character and balloon.
- Integrating the Yaya SHIORI engine to get scripts.
- Using the SakuraScriptEngine to parse scripts.
- Updating SwiftUI views (CharacterView, BalloonView) to display the ghost's state.

The application's AppDelegate is refactored to use this new GhostManager, fixing the issue where the character was not displayed on launch.