### PR TITLE
Improve YayaAdapter startup logging

### DIFF
--- a/Ourin/Yaya/YayaAdapter.swift
+++ b/Ourin/Yaya/YayaAdapter.swift
@@ -32,6 +32,7 @@ final class YayaAdapter {
     /// Create adapter. The helper executable is searched in the app bundle by default.
     init?() {
         guard let url = Bundle.main.url(forAuxiliaryExecutable: "yaya_core") else {
+            NSLog("[YayaAdapter] Could not locate yaya_core executable in bundle")
             return nil
         }
         proc.executableURL = url
@@ -39,7 +40,9 @@ final class YayaAdapter {
         proc.standardOutput = outPipe
         do {
             try proc.run()
+            NSLog("[YayaAdapter] Launched yaya_core at \(url.path)")
         } catch {
+            NSLog("[YayaAdapter] Failed to launch yaya_core at \(url.path): \(error)")
             return nil
         }
     }


### PR DESCRIPTION
## Summary
- add console logs when the YayaAdapter cannot locate or launch `yaya_core`
- log successful launch path for `yaya_core`

## Testing
- `xcodebuild -project Ourin.xcodeproj -scheme Ourin build` *(fails: command not found)*
- `xcodebuild -project Ourin.xcodeproj -scheme Ourin test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c421b40f308322a6549cbd9c01dd9d