### PR TITLE
Fix resource bridge cache invalidation for nil values

### DIFF
--- a/Ourin/ResourceBridge/ResourceBridge.swift
+++ b/Ourin/ResourceBridge/ResourceBridge.swift
@@ -30,11 +30,16 @@ public final class ResourceBridge {
     /// Get resource value for given key via SHIORI. Uses cache if valid.
     public func get(_ key: String) -> String? {
         let now = Date()
-        if let entry = cache[key], now.timeIntervalSince(entry.time) < ttl {
-            return entry.value
+        if let entry = cache[key], let cachedValue = entry.value,
+           now.timeIntervalSince(entry.time) < ttl {
+            return cachedValue
         }
         let value = query(key: key)
-        cache[key] = Entry(value: value, time: now)
+        if let value = value {
+            cache[key] = Entry(value: value, time: now)
+        } else {
+            cache.removeValue(forKey: key)
+        }
         logger.debug("query \(key) -> \(value ?? "nil")")
         return value
     }

--- a/OurinTests/ResourceBridgeTests.swift
+++ b/OurinTests/ResourceBridgeTests.swift
@@ -56,4 +56,18 @@ struct ResourceBridgeTests {
         }
         BridgeToSHIORI.reset()
     }
+
+    @Test
+    func refreshesAfterNilFetch() async throws {
+        BridgeToSHIORI.reset()
+        BridgeToSHIORI.setResource("dynamic.key", value: "")
+        let bridge = ResourceBridge.shared
+        bridge.invalidateAll()
+        let initial = bridge.get("dynamic.key")
+        #expect(initial == nil)
+        BridgeToSHIORI.setResource("dynamic.key", value: "updated")
+        let refreshed = bridge.get("dynamic.key")
+        #expect(refreshed == "updated")
+        BridgeToSHIORI.reset()
+    }
 }


### PR DESCRIPTION
## Summary
- avoid returning cached nil values in ResourceBridge so subsequent queries can observe updates
- clear cache entries when the SHIORI bridge reports a missing resource
- add a regression test that ensures resources refresh after an initial nil fetch

## Testing
- N/A (Package.swift not available; `swift test` cannot run in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f0e0d959a48322b94a584c884192a5