### PR TITLE
Implement CODE_SPEC_DIFF_2026-06 P0-P2 fixes (C/A/B, P1-P4, R1-R5, M1…

### DIFF
--- a/Ourin/Balloon/ImageLoader.swift
+++ b/Ourin/Balloon/ImageLoader.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreGraphics
+import CoreImage
 import ImageIO
 
 /// 画像ファイルを読み込むためのユーティリティ。
@@ -15,8 +16,22 @@ public enum ImageLoader {
     }()
 
     /// Load image at given url. Supports PNG/JPEG/GIF/BMP via Image I/O and ICO/CUR via builtin parser.
+    /// 同名の `.pna`（別アルファファイル）が存在すれば透過マスクとして適用する（BALLOON_1.0M_SPEC）。
     /// URL から画像を読み込んで CGImage を返す
     public static func load(url: URL) throws -> CGImage {
+        let base = try loadRaw(url: url)
+        // PNA（別アルファファイル）が隣にあれば適用する。拡張子を pna に差し替えた兄弟ファイル。
+        let pnaURL = url.deletingPathExtension().appendingPathExtension("pna")
+        if url.pathExtension.lowercased() != "pna",
+           FileManager.default.fileExists(atPath: pnaURL.path),
+           let masked = applyPNA(base: base, pnaURL: pnaURL) {
+            return masked
+        }
+        return base
+    }
+
+    /// PNA を適用せず素の画像のみを読み込む（PNA 自体の読み込みにも使う）。
+    private static func loadRaw(url: URL) throws -> CGImage {
         let data = try Data(contentsOf: url)
         let ext = url.pathExtension.lowercased()
         if ext == "ico" || ext == "cur" {
@@ -30,6 +45,22 @@ public enum ImageLoader {
             return image
         }
         throw NSError(domain: "OurinImageLoader", code: -1, userInfo: [NSLocalizedDescriptionKey:"Unsupported image format"])
+    }
+
+    /// PNA マスク（白=不透明 / 黒=透明のグレースケール）を base のアルファとして合成する。
+    /// BalloonImageLoader.applyPNAMask と同方式（CIBlendWithMask）。
+    private static func applyPNA(base: CGImage, pnaURL: URL) -> CGImage? {
+        guard let maskCG = try? loadRaw(url: pnaURL) else { return nil }
+        let baseCI = CIImage(cgImage: base)
+        let maskCI = CIImage(cgImage: maskCG)
+        let clear = CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 0)).cropped(to: baseCI.extent)
+        guard let output = CIFilter(name: "CIBlendWithMask",
+                                    parameters: [kCIInputImageKey: baseCI,
+                                                 kCIInputBackgroundImageKey: clear,
+                                                 kCIInputMaskImageKey: maskCI])?.outputImage else {
+            return nil
+        }
+        return CIContext(options: nil).createCGImage(output, from: baseCI.extent)
     }
 
     /// 内蔵の ICO/CUR 解析を利用して CGImage を生成する

--- a/Ourin/Balloon/RetinaImageLoader.swift
+++ b/Ourin/Balloon/RetinaImageLoader.swift
@@ -1,0 +1,62 @@
+import Foundation
+import AppKit
+
+/// Retina(高DPI)対応の画像ローダ。
+///
+/// ukagaka のシェル/バルーン画像は通常 1x の PNG を出荷するが、Ourin 拡張として
+/// `name@2x.png`（および `name@3x.png`）の高解像度バリアントがあれば取り込み、
+/// `NSImage` に複数解像度の representation を持たせる。AppKit が表示時の
+/// `backingScaleFactor` に応じて最適な representation を自動選択する。
+///
+/// 返す `NSImage.size` は常に**論理ポイント**（= 1x ピクセル相当）に揃えるため、
+/// ウィンドウサイズ（`NSImage.size` を使用）は Retina でもズレない。
+enum RetinaImageLoader {
+    /// ファイル URL から画像を読み込み、`@2x`/`@3x` バリアントがあれば高解像度 rep として付与する。
+    static func image(contentsOf url: URL) -> NSImage? {
+        let fm = FileManager.default
+        let baseExists = fm.fileExists(atPath: url.path)
+
+        // 1x が存在する場合: それを基準サイズ（論理ポイント）とし、@2x/@3x を rep として追加。
+        if baseExists, let base = NSImage(contentsOf: url) {
+            let logicalSize = base.size
+            for suffix in ["@2x", "@3x"] {
+                guard let variantURL = variant(of: url, suffix: suffix),
+                      fm.fileExists(atPath: variantURL.path),
+                      let rep = bitmapRep(contentsOf: variantURL) else { continue }
+                // representation の論理サイズを 1x と一致させると AppKit がスケールで使い分ける。
+                rep.size = logicalSize
+                base.addRepresentation(rep)
+            }
+            return base
+        }
+
+        // 1x が無く @2x/@3x のみある場合: 最高解像度を読み、論理ポイント（ピクセル/スケール）に縮める。
+        for (suffix, scale) in [("@2x", CGFloat(2)), ("@3x", CGFloat(3))] {
+            guard let variantURL = variant(of: url, suffix: suffix),
+                  fm.fileExists(atPath: variantURL.path),
+                  let img = NSImage(contentsOf: variantURL) else { continue }
+            img.size = NSSize(width: img.size.width / scale, height: img.size.height / scale)
+            return img
+        }
+        return nil
+    }
+
+    /// ファイルパス文字列版（`NSImage(contentsOfFile:)` の置き換え用）。
+    static func image(contentsOfFile path: String) -> NSImage? {
+        image(contentsOf: URL(fileURLWithPath: path))
+    }
+
+    /// `name.ext` → `name<suffix>.ext`（例: surface0.png → surface0@2x.png）
+    private static func variant(of url: URL, suffix: String) -> URL? {
+        let ext = url.pathExtension
+        let stem = url.deletingPathExtension().lastPathComponent
+        guard !stem.isEmpty else { return nil }
+        let name = ext.isEmpty ? "\(stem)\(suffix)" : "\(stem)\(suffix).\(ext)"
+        return url.deletingLastPathComponent().appendingPathComponent(name)
+    }
+
+    private static func bitmapRep(contentsOf url: URL) -> NSImageRep? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return NSBitmapImageRep(data: data)
+    }
+}

--- a/Ourin/ContentView.swift
+++ b/Ourin/ContentView.swift
@@ -1327,7 +1327,7 @@ fileprivate struct ExternalEventsView: View {
             // Send to localhost:9801
         case .http:
             logger.info("Sending sample request via HTTP")
-            // POST to localhost:9810/api/sstp/v1
+            // POST to localhost:9801/api/sstp/v1
         case .xpc:
             logger.info("Sending sample request via XPC")
             // Send via XPC connection
@@ -1336,7 +1336,7 @@ fileprivate struct ExternalEventsView: View {
     
     private func copyCurlCommand() {
         let curlCommand = """
-        curl -X POST http://localhost:9810/api/sstp/v1 \\
+        curl -X POST http://localhost:9801/api/sstp/v1 \\
         -H "Content-Type: text/plain" \\
         -d "\(sampleRequest)"
         """
@@ -1349,11 +1349,11 @@ fileprivate struct ExternalEventsView: View {
         let xpcSnippet = """
         // Swift XPC Client Code
         let connection = NSXPCConnection(machServiceName: "jp.ourin.sstp")
-        connection.remoteObjectInterface = NSXPCInterface(with: OurinSSTPProtocol.self)
+        connection.remoteObjectInterface = NSXPCInterface(with: OurinSSTPXPC.self)
         connection.resume()
-        
-        let service = connection.remoteObjectProxy as? OurinSSTPProtocol
-        service?.deliverSSTP("\(sampleRequest)".data(using: .utf8)!) { response in
+
+        let service = connection.remoteObjectProxy as? OurinSSTPXPC
+        service?.executeSSTP("\(sampleRequest)".data(using: .utf8)!) { response in
             print("Response: \\(response)")
         }
         """
@@ -1715,9 +1715,9 @@ fileprivate struct NetworkStatusView: View {
                 .background(Color.gray.opacity(0.1))
                 .cornerRadius(8)
                 
-                // HTTP (9810) Status
+                // HTTP (9801, 多重化) Status
                 VStack(alignment: .leading) {
-                    Text("HTTP (9810)").font(.headline)
+                    Text("HTTP (9801)").font(.headline)
                     VStack(alignment: .leading, spacing: 10) {
                         HStack {
                             statusIndicator(color: httpRunning ? .green : .gray)
@@ -1840,9 +1840,9 @@ fileprivate struct NetworkStatusView: View {
     private func updateStatus() {
         guard let server = externalServer else { return }
 
-        // サーバーの稼働状態を取得
-        tcpRunning = server.tcp.isRunning
-        httpRunning = server.http.isRunning
+        // サーバーの稼働状態を取得（TCP/HTTP は 9801 単一ポートで多重化）
+        tcpRunning = server.tcpRunning
+        httpRunning = server.httpRunning
         xpcRunning = server.xpc.isRunning
 
         // メトリクスを取得

--- a/Ourin/ExternalServer/OurinExternalServer.swift
+++ b/Ourin/ExternalServer/OurinExternalServer.swift
@@ -7,14 +7,17 @@ import OSLog
 /// 外部からの SSTP イベントを受信する TCP/HTTP/XPC サーバ群を管理するクラス。
 /// 受信した生 SSTP は SSTPParser で解析し SSTPDispatcher へ一本化して処理する（P2-10）。
 public final class OurinExternalServer {
-    /// TCP ベースの SSTP サーバ
-    public let tcp = SstpTcpServer()
-    /// HTTP ベースの SSTP サーバ
-    public let http = SstpHttpServer()
+    /// TCP/HTTP を 9801 単一ポートで多重化するリスナー（生 SSTP と HTTP を先頭行で振り分け）
+    public let unified = UnifiedSstpListener()
     /// XPC 直接通信サーバ
     public let xpc = XpcDirectServer()
     /// OSLog 用ロガー
     private let logger = CompatLogger(subsystem: "Ourin", category: "ExternalServer")
+
+    /// TCP(生 SSTP) が有効かつリスナー稼働中か（UI 表示・互換用）
+    public var tcpRunning: Bool { unified.isRunning && config.enableTCP }
+    /// HTTP が有効かつリスナー稼働中か（UI 表示・互換用）
+    public var httpRunning: Bool { unified.isRunning && config.enableHTTP }
 
     public struct Config {
         var securityLocalOnly: Bool = true
@@ -31,8 +34,7 @@ public final class OurinExternalServer {
 
     /// サーバ群の初期設定を行う
     public init() {
-        tcp.onRequest = { [weak self] in self?.handleRaw($0) ?? "" }
-        http.onRequest = { [weak self] in self?.handleRaw($0) ?? "" }
+        unified.onRequest = { [weak self] in self?.handleRaw($0) ?? "" }
         xpc.onRequest = { [weak self] in self?.handleRaw($0) ?? "" }
         applyRuntimeConfig()
     }
@@ -67,35 +69,22 @@ public final class OurinExternalServer {
     }
 
     private func applyRuntimeConfig() {
-        let tcpConfig = SstpTcpServer.Config(
+        unified.updateConfig(.init(
             timeout: config.timeout,
             maxSize: config.maxPayloadSize
-        )
-        tcp.updateConfig(tcpConfig)
-
-        let httpConfig = SstpHttpServer.Config(
-            timeout: config.timeout,
-            maxSize: config.maxPayloadSize
-        )
-        http.updateConfig(httpConfig)
+        ))
         logger.info("external server runtime config updated")
     }
 
     private func applyListenerState() {
-        if config.enableTCP {
-            if !tcp.isRunning {
-                try? tcp.start()
+        // 生 SSTP / HTTP は同じ 9801 ポートで多重化する。どちらかが有効なら単一リスナーを起動。
+        let wantUnified = config.enableTCP || config.enableHTTP
+        if wantUnified {
+            if !unified.isRunning {
+                try? unified.start()
             }
-        } else if tcp.isRunning {
-            tcp.stop()
-        }
-
-        if config.enableHTTP {
-            if !http.isRunning {
-                try? http.start()
-            }
-        } else if http.isRunning {
-            http.stop()
+        } else if unified.isRunning {
+            unified.stop()
         }
 
         if config.enableXPC {
@@ -122,8 +111,7 @@ public final class OurinExternalServer {
 
     /// すべてのリスナーを停止する。
     public func stop() {
-        tcp.stop()
-        http.stop()
+        unified.stop()
         xpc.stop()
         stopDistributedIpc()
         logger.info("external servers stopped")

--- a/Ourin/ExternalServer/SstpHttpServer.swift
+++ b/Ourin/ExternalServer/SstpHttpServer.swift
@@ -26,7 +26,9 @@ public final class SstpHttpServer {
         return listener != nil
     }
 
-    public func start(host: String = "127.0.0.1", port: UInt16 = 9810) throws {
+    // 仕様(SSTP/1.xM)では HTTP も SSTP と同じ 9801 を多重化して使う。
+    // 単体起動時の既定も 9801 に揃える（通常は UnifiedSstpListener 経由で adopt される）。
+    public func start(host: String = "127.0.0.1", port: UInt16 = 9801) throws {
         listener = try NWListener(using: .tcp, on: NWEndpoint.Port(rawValue: port)!)
         listener?.newConnectionHandler = { [weak self] conn in
             guard let self else { return }
@@ -39,82 +41,90 @@ public final class SstpHttpServer {
 
     public func stop() { listener?.cancel(); listener = nil }
 
-    private func handle(conn: NWConnection) {
-        var buffer = Data()
+    /// 多重化リスナーから、先頭バイトを読み取り済みの接続を引き継いで HTTP として処理する。
+    func adopt(conn: NWConnection, initialBuffer: Data) {
+        handle(conn: conn, initialBuffer: initialBuffer)
+    }
+
+    private func handle(conn: NWConnection, initialBuffer: Data = Data()) {
+        var buffer = initialBuffer
         let deadline = DispatchTime.now() + config.timeout
+        // ヘッダ＋本文が揃っていれば処理して true を返す。途中なら false（追加読込が必要）。
+        func tryProcess() -> Bool {
+            if buffer.count > self.config.maxSize { self.sendErrorResponse(conn, status: 413); return true }
+            guard let headerEnd = buffer.range(of: Data([13,10,13,10])) else { return false }
+            let header = buffer.subdata(in: 0..<headerEnd.upperBound)
+            let headersText = String(data: header, encoding: .utf8) ?? ""
+            let headerLines = headersText.split(separator: "\n").map {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            guard let requestLine = headerLines.first,
+                  let request = Self.parseRequestLine(requestLine) else {
+                self.sendErrorResponse(conn, status: 400)
+                return true
+            }
+            guard request.method == "POST" else {
+                self.sendErrorResponse(conn, status: 405)
+                return true
+            }
+            guard request.path == "/api/sstp/v1" else {
+                self.sendErrorResponse(conn, status: 404)
+                return true
+            }
+
+            var contentLength = 0
+            var hasContentLength = false
+            var originHeader: String?
+            for line in headerLines.dropFirst() {
+                if line.lowercased().hasPrefix("content-length:") {
+                    let v = line.split(separator: ":", maxSplits: 1)[1].trimmingCharacters(in: .whitespaces)
+                    contentLength = Int(v) ?? 0
+                    hasContentLength = true
+                } else if line.lowercased().hasPrefix("origin:") {
+                    let v = line.split(separator: ":", maxSplits: 1)[1].trimmingCharacters(in: .whitespaces)
+                    originHeader = v
+                }
+            }
+            guard hasContentLength else {
+                self.sendErrorResponse(conn, status: 411)
+                return true
+            }
+            if let originHeader, !Self.isAcceptedOrigin(originHeader) {
+                self.sendErrorResponse(conn, status: 403)
+                return true
+            }
+            let bodyStart = headerEnd.upperBound
+            // 本文がまだ全部届いていなければ追加読込を待つ。
+            guard buffer.count - bodyStart >= contentLength else { return false }
+            let body = buffer.subdata(in: bodyStart..<bodyStart+contentLength)
+            guard let sstp = Self.decode(body) else { return false }
+            let start = Date()
+            let routedSstp = Self.injectSecurityHeaders(into: sstp, origin: originHeader)
+            let respSstp = self.onRequest?(routedSstp) ?? "SSTP/1.1 204 No Content\r\n\r\n"
+            let duration = Date().timeIntervalSince(start)
+            let lines = [
+                "HTTP/1.1 200 OK\r",
+                "Content-Type: text/plain; charset=UTF-8\r",
+                "Content-Length: \(respSstp.utf8.count)\r",
+                "\r",
+                respSstp
+            ]
+            let http = lines.joined()
+            self.logger.info("http size=\(buffer.count) duration=\(duration)")
+            ServerMetrics.shared.record(duration: duration, error: false)
+            conn.send(content: http.data(using: .utf8), completion: .contentProcessed { _ in conn.cancel() })
+            return true
+        }
         func readMore() {
             conn.receive(minimumIncompleteLength: 1, maximumLength: 8192) { data, _, isComplete, error in
                 if let d = data { buffer.append(d) }
-                if buffer.count > self.config.maxSize { self.sendErrorResponse(conn, status: 413); return }
                 if DispatchTime.now() > deadline { self.sendErrorResponse(conn, status: 408); return }
+                if tryProcess() { return }
                 if isComplete || error != nil { conn.cancel(); return }
-                if let headerEnd = buffer.range(of: Data([13,10,13,10])) {
-                    let header = buffer.subdata(in: 0..<headerEnd.upperBound)
-                    let headersText = String(data: header, encoding: .utf8) ?? ""
-                    let headerLines = headersText.split(separator: "\n").map {
-                        $0.trimmingCharacters(in: .whitespacesAndNewlines)
-                    }
-                    guard let requestLine = headerLines.first,
-                          let request = Self.parseRequestLine(requestLine) else {
-                        self.sendErrorResponse(conn, status: 400)
-                        return
-                    }
-                    guard request.method == "POST" else {
-                        self.sendErrorResponse(conn, status: 405)
-                        return
-                    }
-                    guard request.path == "/api/sstp/v1" else {
-                        self.sendErrorResponse(conn, status: 404)
-                        return
-                    }
-
-                    var contentLength = 0
-                    var hasContentLength = false
-                    var originHeader: String?
-                    for line in headerLines.dropFirst() {
-                        if line.lowercased().hasPrefix("content-length:") {
-                            let v = line.split(separator: ":", maxSplits: 1)[1].trimmingCharacters(in: .whitespaces)
-                            contentLength = Int(v) ?? 0
-                            hasContentLength = true
-                        } else if line.lowercased().hasPrefix("origin:") {
-                            let v = line.split(separator: ":", maxSplits: 1)[1].trimmingCharacters(in: .whitespaces)
-                            originHeader = v
-                        }
-                    }
-                    guard hasContentLength else {
-                        self.sendErrorResponse(conn, status: 411)
-                        return
-                    }
-                    if let originHeader, !Self.isAcceptedOrigin(originHeader) {
-                        self.sendErrorResponse(conn, status: 403)
-                        return
-                    }
-                    let bodyStart = headerEnd.upperBound
-                    if buffer.count - bodyStart >= contentLength {
-                        let body = buffer.subdata(in: bodyStart..<bodyStart+contentLength)
-                        if let sstp = Self.decode(body) {
-                            let start = Date()
-                            let routedSstp = Self.injectSecurityHeaders(into: sstp, origin: originHeader)
-                            let respSstp = self.onRequest?(routedSstp) ?? "SSTP/1.1 204 No Content\r\n\r\n"
-                            let duration = Date().timeIntervalSince(start)
-                            let lines = [
-                                "HTTP/1.1 200 OK\r",
-                                "Content-Type: text/plain; charset=UTF-8\r",
-                                "Content-Length: \(respSstp.utf8.count)\r",
-                                "\r",
-                                respSstp
-                            ]
-                            let http = lines.joined()
-                            self.logger.info("http size=\(buffer.count) duration=\(duration)")
-                            ServerMetrics.shared.record(duration: duration, error: false)
-                            conn.send(content: http.data(using: .utf8), completion: .contentProcessed { _ in conn.cancel() })
-                            return
-                        }
-                    }
-                }
                 readMore()
             }
         }
+        if tryProcess() { return }
         readMore()
     }
 

--- a/Ourin/ExternalServer/SstpTcpServer.swift
+++ b/Ourin/ExternalServer/SstpTcpServer.swift
@@ -40,30 +40,42 @@ public final class SstpTcpServer {
 
     public func stop() { listener?.cancel(); listener = nil }
 
-    private func handle(conn: NWConnection) {
-        var buffer = Data()
+    /// 多重化リスナーから、先頭バイトを読み取り済みの接続を引き継いで生 SSTP として処理する。
+    func adopt(conn: NWConnection, initialBuffer: Data) {
+        handle(conn: conn, initialBuffer: initialBuffer)
+    }
+
+    private func handle(conn: NWConnection, initialBuffer: Data = Data()) {
+        var buffer = initialBuffer
         let deadline = DispatchTime.now() + config.timeout
+        // バッファに完全なリクエスト（CRLF+空行終端）が揃っていれば処理して true を返す。
+        func tryProcess() -> Bool {
+            if buffer.count > self.config.maxSize { self.sendErrorResponse(conn, status: 413); return true }
+            if let range = buffer.range(of: Data([13,10,13,10])) {
+                let header = buffer.subdata(in: 0..<range.lowerBound)
+                if let text = Self.decode(header) {
+                    let start = Date()
+                    let resp = self.onRequest?(text) ?? "SSTP/1.1 204 No Content\r\n\r\n"
+                    let duration = Date().timeIntervalSince(start)
+                    self.logger.info("tcp request size=\(buffer.count) duration=\(duration)")
+                    ServerMetrics.shared.record(duration: duration, error: false)
+                    conn.send(content: resp.data(using: .utf8), completion: .contentProcessed { _ in conn.cancel() })
+                    return true
+                }
+            }
+            return false
+        }
         func readMore() {
             conn.receive(minimumIncompleteLength: 1, maximumLength: 4096) { data, _, isComplete, error in
                 if let d = data { buffer.append(d) }
-                if buffer.count > self.config.maxSize { self.sendErrorResponse(conn, status: 413); return }
                 if DispatchTime.now() > deadline { self.sendErrorResponse(conn, status: 408); return }
+                if tryProcess() { return }
                 if isComplete || error != nil { conn.cancel(); return }
-                if let range = buffer.range(of: Data([13,10,13,10])) {
-                    let header = buffer.subdata(in: 0..<range.lowerBound)
-                    if let text = Self.decode(header) {
-                        let start = Date()
-                        let resp = self.onRequest?(text) ?? "SSTP/1.1 204 No Content\r\n\r\n"
-                        let duration = Date().timeIntervalSince(start)
-                        self.logger.info("tcp request size=\(buffer.count) duration=\(duration)")
-                        ServerMetrics.shared.record(duration: duration, error: false)
-                        conn.send(content: resp.data(using: .utf8), completion: .contentProcessed { _ in conn.cancel() })
-                        return
-                    }
-                }
                 readMore()
             }
         }
+        // 引き継いだバッファに既に全リクエストが含まれている場合があるので先に検査する。
+        if tryProcess() { return }
         readMore()
     }
 

--- a/Ourin/ExternalServer/UnifiedSstpListener.swift
+++ b/Ourin/ExternalServer/UnifiedSstpListener.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Network
+import OSLog
+
+/// 9801 単一ポートで HTTP と 生 SSTP を多重化して受信するリスナー。
+///
+/// SSP 互換: 直 SSTP (`SEND SSTP/1.x ...`) と HTTP (`POST /api/sstp/v1 HTTP/1.1`) は
+/// 同一ポート(9801)で待ち受け、先頭リクエスト行の終端トークンで判別する。
+///   - `... HTTP/1.x` → HTTP として SstpHttpServer に委譲
+///   - それ以外（`... SSTP/1.x`）→ 生 SSTP として SstpTcpServer に委譲
+/// これにより、HTTP を別ポート(旧 9810)に逃がす必要がなくなる。
+public final class UnifiedSstpListener {
+    private var listener: NWListener?
+    public var onRequest: ((String) -> String)?
+    private let logger = CompatLogger(subsystem: "Ourin", category: "SSTP_UNIFIED")
+
+    private var config = Config()
+    public struct Config {
+        var timeout: TimeInterval = 5
+        var maxSize: Int = 64 * 1024
+    }
+
+    /// プロトコル別ハンドラ（リスナーは持たず、引き継いだ接続のみ処理する）
+    private let tcp = SstpTcpServer()
+    private let http = SstpHttpServer()
+
+    public init() {}
+
+    public func updateConfig(_ config: Config) {
+        self.config = config
+        tcp.updateConfig(.init(timeout: config.timeout, maxSize: config.maxSize))
+        http.updateConfig(.init(timeout: config.timeout, maxSize: config.maxSize))
+    }
+
+    /// サーバーが稼働中かどうかを返す
+    public var isRunning: Bool { listener != nil }
+
+    public func start(host: String = "127.0.0.1", port: UInt16 = 9801) throws {
+        let forward: (String) -> String = { [weak self] raw in
+            self?.onRequest?(raw) ?? "SSTP/1.1 204 No Content\r\n\r\n"
+        }
+        tcp.onRequest = forward
+        http.onRequest = forward
+
+        listener = try NWListener(using: .tcp, on: NWEndpoint.Port(rawValue: port)!)
+        listener?.newConnectionHandler = { [weak self] conn in
+            guard let self else { return }
+            conn.start(queue: .global())
+            self.route(conn: conn)
+        }
+        listener?.start(queue: .main)
+        logger.info("unified listen \(host):\(port)")
+    }
+
+    public func stop() { listener?.cancel(); listener = nil }
+
+    /// 先頭リクエスト行を覗いて HTTP / 生 SSTP のどちらに委譲するか決める。
+    private func route(conn: NWConnection) {
+        var buffer = Data()
+        let deadline = DispatchTime.now() + config.timeout
+        func readMore() {
+            conn.receive(minimumIncompleteLength: 1, maximumLength: 4096) { data, _, isComplete, error in
+                if let d = data { buffer.append(d) }
+                if buffer.count > self.config.maxSize { conn.cancel(); return }
+                if DispatchTime.now() > deadline { conn.cancel(); return }
+                // 先頭行(最初の CRLF まで)が揃ったら判別する。
+                if let lineEnd = buffer.range(of: Data([13, 10])) {
+                    let lineData = buffer.subdata(in: 0..<lineEnd.lowerBound)
+                    let line = (String(data: lineData, encoding: .utf8) ?? "").uppercased()
+                    // HTTP リクエスト行は "<METHOD> <path> HTTP/1.x"。生 SSTP は "<METHOD> SSTP/1.x"。
+                    if line.contains(" HTTP/") {
+                        self.http.adopt(conn: conn, initialBuffer: buffer)
+                    } else {
+                        self.tcp.adopt(conn: conn, initialBuffer: buffer)
+                    }
+                    return
+                }
+                if isComplete || error != nil { conn.cancel(); return }
+                readMore()
+            }
+        }
+        readMore()
+    }
+}

--- a/Ourin/ExternalServer/XpcDirectServer.swift
+++ b/Ourin/ExternalServer/XpcDirectServer.swift
@@ -2,11 +2,9 @@ import Foundation
 import OSLog
 
 /// XPC 経由で SSTP メッセージを受信するサーバ。
-@objc public protocol OurinExternalSstpXPC {
-    func deliverSSTP(_ request: Data, with reply: @escaping (Data) -> Void)
-}
-
-public final class XpcDirectServer: NSObject, NSXPCListenerDelegate, OurinExternalSstpXPC {
+/// プロトコルは DirectSSTP と共通の `OurinSSTPXPC`（`executeSSTP(_:withReply:)`）に統一する
+/// （SSTP/1.xM 仕様準拠。旧 `OurinExternalSstpXPC.deliverSSTP` は廃止）。
+public final class XpcDirectServer: NSObject, NSXPCListenerDelegate, OurinSSTPXPC {
     private let listener: NSXPCListener
     public var onRequest: ((String) -> String)?
     private let logger = CompatLogger(subsystem: "Ourin", category: "SSTP_XPC")
@@ -36,14 +34,14 @@ public final class XpcDirectServer: NSObject, NSXPCListenerDelegate, OurinExtern
     }
 
     public func listener(_ listener: NSXPCListener, shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
-        newConnection.exportedInterface = NSXPCInterface(with: OurinExternalSstpXPC.self)
+        newConnection.exportedInterface = NSXPCInterface(with: OurinSSTPXPC.self)
         newConnection.exportedObject = self
         newConnection.resume()
         return true
     }
 
     /// XPC クライアントから SSTP データを受け取り応答する。
-    public func deliverSSTP(_ request: Data, with reply: @escaping (Data) -> Void) {
+    public func executeSSTP(_ request: Data, withReply reply: @escaping (Data) -> Void) {
         guard request.count <= maxSize else {
             logger.fault("xpc oversized")
             ServerMetrics.shared.record(duration: 0, error: true)

--- a/Ourin/Ghost/BalloonConfig.swift
+++ b/Ourin/Ghost/BalloonConfig.swift
@@ -208,7 +208,8 @@ class BalloonImageLoader {
             image = maskedImage
             NSLog("[BalloonImageLoader] Loaded \(filename) with PNA transparency")
         } else {
-            image = NSImage(contentsOfFile: imagePath)
+            // @2x/@3x バリアントがあれば高解像度 rep を取り込む（Retina 対応）
+            image = RetinaImageLoader.image(contentsOfFile: imagePath)
         }
 
         if let image = image {
@@ -251,7 +252,7 @@ class BalloonImageLoader {
         }
 
         let imagePath = (balloonPath as NSString).appendingPathComponent(filename)
-        guard let image = NSImage(contentsOfFile: imagePath) else {
+        guard let image = RetinaImageLoader.image(contentsOfFile: imagePath) else {
             return nil
         }
 
@@ -268,7 +269,7 @@ class BalloonImageLoader {
         }
 
         let imagePath = (balloonPath as NSString).appendingPathComponent(filename)
-        guard let image = NSImage(contentsOfFile: imagePath) else {
+        guard let image = RetinaImageLoader.image(contentsOfFile: imagePath) else {
             return nil
         }
 
@@ -285,7 +286,7 @@ class BalloonImageLoader {
         }
 
         let imagePath = (balloonPath as NSString).appendingPathComponent(filename)
-        guard let image = NSImage(contentsOfFile: imagePath) else {
+        guard let image = RetinaImageLoader.image(contentsOfFile: imagePath) else {
             return nil
         }
 
@@ -302,7 +303,7 @@ class BalloonImageLoader {
         }
 
         let imagePath = (balloonPath as NSString).appendingPathComponent(filename)
-        guard let image = NSImage(contentsOfFile: imagePath) else {
+        guard let image = RetinaImageLoader.image(contentsOfFile: imagePath) else {
             return nil
         }
 

--- a/Ourin/Ghost/BalloonView.swift
+++ b/Ourin/Ghost/BalloonView.swift
@@ -42,16 +42,9 @@ struct BalloonView: View {
                 }
 
                 // Text overlay with proper positioning
-                styledText(for: viewModel)
+                decoratedText(for: viewModel)
                     .lineLimit(nil)
                     .multilineTextAlignment(textAlignment(for: viewModel.textAlign))
-                    .foregroundColor(Color(viewModel.anchorActive ? viewModel.anchorFontColor : viewModel.fontColor))
-                    .shadow(
-                        color: Color(viewModel.shadowColor),
-                        radius: shadowRadius(for: viewModel),
-                        x: viewModel.shadowStyle == .offset ? 1 : 0,
-                        y: viewModel.shadowStyle == .offset ? -1 : 0
-                    )
                     .frame(
                         width: balloonWidth - CGFloat((config?.originX ?? 20) * 2),
                         height: nil,
@@ -133,14 +126,31 @@ struct BalloonView: View {
         return 0
     }
 
-    private func shadowRadius(for vm: BalloonViewModel) -> CGFloat {
+    /// 文字色＋装飾（影／縁取り）を適用したテキストビューを返す。
+    /// - `.offset`: ドロップシャドウ（右下 1px）
+    /// - `.outline`: 8方向のオフセット影による縁取り（単純なブラーではなく実際のアウトライン）
+    @ViewBuilder
+    private func decoratedText(for vm: BalloonViewModel) -> some View {
+        let base = styledText(for: vm)
+            .foregroundColor(Color(vm.anchorActive ? vm.anchorFontColor : vm.fontColor))
         switch vm.shadowStyle {
         case .none:
-            return 0
+            base
         case .offset:
-            return 1
+            base.shadow(color: Color(vm.shadowColor), radius: 1, x: 1, y: -1)
         case .outline:
-            return max(1, vm.outlineWidth)
+            let w = max(1, vm.outlineWidth)
+            let c = Color(vm.shadowColor)
+            // 上下左右＋斜め4方向に縁取り色の影を重ね、文字の輪郭を描く
+            base
+                .shadow(color: c, radius: 0, x:  w, y: 0)
+                .shadow(color: c, radius: 0, x: -w, y: 0)
+                .shadow(color: c, radius: 0, x: 0, y:  w)
+                .shadow(color: c, radius: 0, x: 0, y: -w)
+                .shadow(color: c, radius: 0, x:  w, y:  w)
+                .shadow(color: c, radius: 0, x: -w, y: -w)
+                .shadow(color: c, radius: 0, x:  w, y: -w)
+                .shadow(color: c, radius: 0, x: -w, y:  w)
         }
     }
 }

--- a/Ourin/Ghost/GhostManager+Balloon.swift
+++ b/Ourin/Ghost/GhostManager+Balloon.swift
@@ -134,11 +134,15 @@ extension GhostManager {
 
             if id.hasPrefix("On") {
                 EventBridge.shared.notifyCustom(id, params: params)
+                forwardEventToPlugins(id: id, references: references)
             } else {
                 var exParams = params
                 exParams["Reference1"] = id
                 EventBridge.shared.notifyCustom("OnAnchorSelectEx", params: exParams)
                 EventBridge.shared.notifyCustom("OnAnchorSelect", params: ["Reference0": id])
+                // プラグインへも横流し（OnAnchorSelect: Reference0=アンカーID）
+                forwardEventToPlugins(id: "OnAnchorSelect", references: [id])
+                forwardEventToPlugins(id: "OnAnchorSelectEx", references: references + [id])
             }
         case .script(let script):
             sakuraEngine.run(script: script)

--- a/Ourin/Ghost/GhostManager+Surface.swift
+++ b/Ourin/Ghost/GhostManager+Surface.swift
@@ -31,6 +31,9 @@ extension GhostManager {
                     return
                 }
 
+                // 遅延生成: 未作成スコープのウィンドウ/VM をここで生成する（大量キャラ対応）
+                self.ensureCharacterWindow(for: scope)
+
                 if let vm = self.characterViewModels[scope] {
                     vm.image = image
                     vm.currentSurfaceID = id
@@ -84,7 +87,8 @@ extension GhostManager {
 
         for name in candidates {
             let url = shellURL.appendingPathComponent(name)
-            if FileManager.default.fileExists(atPath: url.path), let img = NSImage(contentsOf: url) {
+            // @2x/@3x バリアントがあれば高解像度 rep を取り込む（Retina 対応）
+            if FileManager.default.fileExists(atPath: url.path), let img = RetinaImageLoader.image(contentsOf: url) {
                 // PNA マスクがあれば適用（白=不透明、黒=透明として扱う想定）
                 let pnaURL = url.deletingPathExtension().appendingPathExtension("pna")
                 if FileManager.default.fileExists(atPath: pnaURL.path),

--- a/Ourin/Ghost/GhostManager+System.swift
+++ b/Ourin/Ghost/GhostManager+System.swift
@@ -14,7 +14,8 @@ extension GhostManager {
 
     // MARK: - Ghost Booting via SSTP
     
-    /// Boot another ghost using SSTP NOTIFY command
+    /// Boot another ghost (\+). 複数ゴースト同時実行に対応: 対象ゴーストを別 GhostManager として
+    /// 同時起動する。起動できない場合は従来の SSTP NOTIFY 通知にフォールバックする。
     func bootOtherGhost(name: String? = nil) {
         let installedGhosts = NarRegistry.shared.installedGhosts()
         let currentGhostName = ghostConfig?.name
@@ -24,9 +25,18 @@ extension GhostManager {
             ? (candidates.randomElement() ?? currentGhostName ?? "default")
             : provided
         Log.debug("[GhostManager] Attempting to boot ghost: \(ghostName)")
-        
-        sendSSTPNotify(event: "OnBoot", references: ["Reference0": ghostName])
-        EventBridge.shared.notify(.OnOtherGhostBooted, params: ["Reference0": ghostName])
+
+        // 追加ゴーストとして in-process で同時起動する（プライマリは置き換えない）。
+        DispatchQueue.main.async {
+            if let appDelegate = NSApp.delegate as? AppDelegate,
+               appDelegate.launchAdditionalGhost(named: ghostName) != nil {
+                EventBridge.shared.notify(.OnOtherGhostBooted, params: ["Reference0": ghostName])
+                return
+            }
+            // フォールバック: 外部インスタンス向け SSTP 通知
+            self.sendSSTPNotify(event: "OnBoot", references: ["Reference0": ghostName])
+            EventBridge.shared.notify(.OnOtherGhostBooted, params: ["Reference0": ghostName])
+        }
     }
     
     /// Boot all ghosts by broadcasting SSTP
@@ -361,6 +371,13 @@ extension GhostManager {
     }
     
     /// Display choice dialog when choices are ready
+    /// 選択肢/アンカー選択イベントを、登録済みプラグインへも横流しする（PLUGIN_EVENT/2.0M）。
+    /// EventBridge への notifyCustom と並行して PluginEventDispatcher.onArbitraryEvent を呼ぶ。
+    func forwardEventToPlugins(id: String, references: [String], notify: Bool = false) {
+        guard let dispatcher = (NSApp.delegate as? AppDelegate)?.pluginDispatcher else { return }
+        dispatcher.onArbitraryEvent(id: id, refs: references, notify: notify)
+    }
+
     func showChoiceDialog() {
         guard !pendingChoices.isEmpty else { return }
         EventBridge.shared.notify(.OnChoiceEnter, params: ["Reference0": String(pendingChoices.count)])
@@ -423,6 +440,9 @@ extension GhostManager {
                 ]
                 EventBridge.shared.notifyCustom("OnChoiceSelect", params: params)
                 EventBridge.shared.notifyCustom("OnChoiceSelectEx", params: params)
+                // プラグインへも横流し（Reference0 に選択タイトル）
+                self.forwardEventToPlugins(id: "OnChoiceSelect", references: [choice.title])
+                self.forwardEventToPlugins(id: "OnChoiceSelectEx", references: [choice.title])
 
                 // Trigger OnChoiceHover event when choice is made
                 EventBridge.shared.notifyCustom("OnChoiceHover", params: params)
@@ -869,11 +889,11 @@ extension GhostManager {
         }
 
         Log.info("[GhostManager] Checking for ghost updates at homeurl: \(updateURL)")
-        NarInstaller().checkUpdates(homeURLString: updateURL) { result in
+        let installer = NarInstaller()
+        installer.checkUpdates(homeURLString: updateURL) { result in
             switch result {
             case .success(let entries):
                 let fileList = entries.map(\.lastPathComponent).joined(separator: ",")
-                let reason = entries.isEmpty ? "none" : "changed"
                 self.emitUpdatePipelineEvent(base: "OnUpdate", stage: "OnMD5CompareBegin", params: [
                     "Reference0": updateURL,
                     "Reference1": String(entries.count)
@@ -886,11 +906,6 @@ extension GhostManager {
                     "Reference0": fileList,
                     "Reference3": "ghost"
                 ])
-                EventBridge.shared.notify(.OnUpdateComplete, params: [
-                    "Reference0": reason,
-                    "Reference1": fileList,
-                    "Reference3": "ghost"
-                ])
                 let first = entries.first?.absoluteString ?? ""
                 EventBridge.shared.notifyCustom("OnUpdateCheckComplete", params: [
                     "Reference0": "ghost",
@@ -898,13 +913,42 @@ extension GhostManager {
                     "Reference2": String(entries.count),
                     "Reference3": options.joined(separator: ",")
                 ])
-                self.emitUpdateResultEvents(
-                    target: "ghost",
-                    reason: reason,
-                    fileList: fileList,
-                    explorerPath: self.ghostURL.path
-                )
-                Log.debug("[GhostManager] Ghost update check completed entries=\(entries.count)")
+
+                // 変更が無ければ即完了。あればダウンロード→適用してから完了イベントを出す。
+                guard !entries.isEmpty else {
+                    EventBridge.shared.notify(.OnUpdateComplete, params: [
+                        "Reference0": "none",
+                        "Reference1": "",
+                        "Reference3": "ghost"
+                    ])
+                    self.emitUpdateResultEvents(target: "ghost", reason: "none", fileList: "", explorerPath: self.ghostURL.path)
+                    Log.debug("[GhostManager] Ghost update: no changes")
+                    return
+                }
+                self.emitUpdatePipelineEvent(base: "OnUpdate", stage: "OnDownloadBegin", params: [
+                    "Reference0": updateURL,
+                    "Reference1": String(entries.count)
+                ])
+                installer.downloadAndApply(entries: entries, homeURLString: updateURL, targetRoot: self.ghostURL) { applied in
+                    let appliedList = applied.joined(separator: ",")
+                    let reason = applied.isEmpty ? "none" : "changed"
+                    self.emitUpdatePipelineEvent(base: "OnUpdate", stage: "OnDownloadComplete", params: [
+                        "Reference0": updateURL,
+                        "Reference1": String(applied.count)
+                    ])
+                    EventBridge.shared.notify(.OnUpdateComplete, params: [
+                        "Reference0": reason,
+                        "Reference1": appliedList.isEmpty ? fileList : appliedList,
+                        "Reference3": "ghost"
+                    ])
+                    self.emitUpdateResultEvents(
+                        target: "ghost",
+                        reason: reason,
+                        fileList: appliedList.isEmpty ? fileList : appliedList,
+                        explorerPath: self.ghostURL.path
+                    )
+                    Log.debug("[GhostManager] Ghost update applied=\(applied.count)/\(entries.count)")
+                }
             case .failure(let error):
                 Log.info("[GhostManager] Ghost update check failed: \(error)")
                 let reason = self.normalizeUpdateFailureReason(error)

--- a/Ourin/Ghost/GhostManager+Window.swift
+++ b/Ourin/Ghost/GhostManager+Window.swift
@@ -51,11 +51,23 @@ extension GhostManager {
 
     func setupWindows() {
         Log.debug("[GhostManager] Setting up windows")
-        // Create Character Windows for scope 0 (master), 1 (partner), and potentially 2-3 (additional characters)
-        // Always create at least scope 0 and 1; additional scopes can be created dynamically
-        for scope in 0..<4 {
+        // よく使う scope 0(本体)/1(相方) のみ先行生成する。
+        // 追加キャラ（\p[N] / scope>=2）は参照時に ensureCharacterWindow で遅延生成し、
+        // 多数キャラ・複数ゴーストでも起動コストとメモリを抑える（大量表示対応）。
+        for scope in 0..<2 {
             setupCharacterWindow(for: scope)
         }
+    }
+
+    /// 指定スコープのキャラウィンドウが未生成なら生成して返す（遅延生成・大量キャラ対応）。
+    /// NSWindow を扱うため必ずメインスレッドで呼ぶこと。冪等。
+    @discardableResult
+    func ensureCharacterWindow(for scope: Int) -> NSWindow? {
+        if let existing = characterWindows[scope] { return existing }
+        guard scope >= 0 else { return nil }
+        Log.debug("[GhostManager] Lazily creating character window for scope \(scope)")
+        setupCharacterWindow(for: scope)
+        return characterWindows[scope]
     }
 
     func setupCharacterWindow(for scope: Int) {

--- a/Ourin/Ghost/GhostManager.swift
+++ b/Ourin/Ghost/GhostManager.swift
@@ -2403,6 +2403,10 @@ class GhostManager: NSObject, SakuraScriptEngineDelegate {
                 // OnClose 応答スクリプトの再生完了後に終了する（スクリプトが \- を含まない場合の保険）
                 if terminateAfterPlayback {
                     finalizeTermination()
+                } else if !pendingChoices.isEmpty {
+                    // \q / \__q で蓄積された選択肢を再生完了後に提示する。
+                    // 選択時に OnChoiceSelect(Ex) が発火し、プラグインへも横流しされる（showChoiceDialog 内）。
+                    showChoiceDialog()
                 }
                 return
             }
@@ -2424,8 +2428,8 @@ class GhostManager: NSObject, SakuraScriptEngineDelegate {
                 currentScope = id
                 Log.debug("[GhostManager] Switched to scope \(id)")
 
-                // Show the character window for this scope (in case it was hidden)
-                if let window = characterWindows[id] {
+                // Show the character window for this scope (遅延生成: 未作成スコープはここで生成)
+                if let window = ensureCharacterWindow(for: id) {
                     window.orderFront(nil)
                     Log.debug("[GhostManager] Ordered scope \(id) window to front")
                 }

--- a/Ourin/HeadlineHost/HeadlineModule.swift
+++ b/Ourin/HeadlineHost/HeadlineModule.swift
@@ -26,8 +26,9 @@ public struct HeadlineModule: Hashable {
             throw NSError(domain: "HeadlineModule", code: -2, userInfo: [NSLocalizedDescriptionKey: "execute not found"])
         }
         self.execute = exe
-        self.load = sym("load")
-        self.unload = sym("unload")
+        // ukagaka DLL 規約: `loadu` は UTF-8 パス版 load。存在すれば優先（macOS のパスは UTF-8）。
+        self.load = sym("loadu") ?? sym("load")
+        self.unload = sym("unloadu") ?? sym("unload")
     }
 
     /// Send raw wire text to the module and get UTF-8 response string

--- a/Ourin/NarInstall/LocalNarInstaller.swift
+++ b/Ourin/NarInstall/LocalNarInstaller.swift
@@ -183,6 +183,83 @@ final class NarInstaller {
         fetchUpdateDescriptor(from: candidates, baseURL: URL(string: baseWithSlash) ?? base, completion: completion)
     }
 
+    /// 更新記述子で列挙されたファイルを実ダウンロードし設置先へ適用する。
+    /// - `.nar`/`.zip` は `install(fromNar:)` でパッケージ展開（install.txt に従う）。
+    /// - それ以外は `homeURLString` を基準にした相対パスで `targetRoot` 配下へ保存（増分更新）。
+    /// - Parameters:
+    ///   - entries: ダウンロード対象 URL（checkUpdates の結果）
+    ///   - homeURLString: 相対パス算出の基準（ゴーストの homeurl）
+    ///   - targetRoot: 増分ファイルの設置先ルート（通常はゴーストのルート URL）
+    ///   - completion: 適用できたファイル名（lastPathComponent）の配列を返す
+    func downloadAndApply(entries: [URL], homeURLString: String, targetRoot: URL,
+                          completion: @escaping ([String]) -> Void) {
+        guard !entries.isEmpty else { completion([]); return }
+        let baseWithSlash = homeURLString.hasSuffix("/") ? homeURLString : "\(homeURLString)/"
+        let group = DispatchGroup()
+        let lock = NSLock()
+        var applied: [String] = []
+
+        for entry in entries {
+            group.enter()
+            URLSession.shared.downloadTask(with: entry) { [weak self] local, response, error in
+                defer { group.leave() }
+                guard let self, let local else { return }
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 200
+                guard (200..<300).contains(statusCode) else {
+                    self.log.warning("update download failed status=\(statusCode,) url=\(entry.absoluteString,)")
+                    return
+                }
+                let ext = entry.pathExtension.lowercased()
+                do {
+                    if ext == "nar" || ext == "zip" {
+                        // パッケージ更新: 一時ファイルへ拡張子付きでコピーしてから install
+                        let tmp = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+                            .appendingPathComponent("OurinUpd_\(UUID().uuidString).\(ext)")
+                        try? FileManager.default.removeItem(at: tmp)
+                        try FileManager.default.moveItem(at: local, to: tmp)
+                        defer { try? FileManager.default.removeItem(at: tmp) }
+                        _ = try self.install(fromNar: tmp)
+                    } else {
+                        // 増分ファイル更新: homeurl 基準の相対パスへ保存
+                        try self.applyIncrementalFile(downloaded: local, entry: entry,
+                                                      baseWithSlash: baseWithSlash, targetRoot: targetRoot)
+                    }
+                    lock.lock(); applied.append(entry.lastPathComponent); lock.unlock()
+                } catch {
+                    self.log.warning("update apply failed: \(String(describing: error),) url=\(entry.absoluteString,)")
+                }
+            }.resume()
+        }
+        group.notify(queue: .global()) { completion(applied) }
+    }
+
+    /// 増分更新ファイルを homeurl 基準の相対パスで targetRoot 配下へ保存する（パストラバーサル防止つき）。
+    private func applyIncrementalFile(downloaded: URL, entry: URL, baseWithSlash: String, targetRoot: URL) throws {
+        var relative = entry.absoluteString
+        if relative.hasPrefix(baseWithSlash) {
+            relative = String(relative.dropFirst(baseWithSlash.count))
+        } else {
+            relative = entry.lastPathComponent
+        }
+        relative = (relative.removingPercentEncoding ?? relative)
+            .replacingOccurrences(of: "\\", with: "/")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard !relative.isEmpty, !relative.contains("..") else {
+            throw Error.invalidDeletePath(relative)
+        }
+        let dest = targetRoot.appendingPathComponent(relative)
+        let resolved = dest.resolvingSymlinksInPath()
+        let rootResolved = targetRoot.resolvingSymlinksInPath()
+        guard resolved.path.hasPrefix(rootResolved.path) || dest.path.hasPrefix(targetRoot.path) else {
+            throw Error.zipSlipDetected(dest.path)
+        }
+        try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if FileManager.default.fileExists(atPath: dest.path) {
+            try FileManager.default.removeItem(at: dest)
+        }
+        try FileManager.default.moveItem(at: downloaded, to: dest)
+    }
+
     private func fetchUpdateDescriptor(from candidates: [URL], baseURL: URL, completion: @escaping (Result<[URL], Swift.Error>) -> Void) {
         guard let current = candidates.first else {
             completion(.failure(Error.updateDescriptorNotFound))

--- a/Ourin/OurinApp.swift
+++ b/Ourin/OurinApp.swift
@@ -92,8 +92,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     var pluginDispatcher: PluginEventDispatcher?
     /// NAR インストーラ
     private let narInstaller = NarInstaller()
-    /// The currently running ghost's manager.
+    /// The currently running ghost's manager (primary). 既存の単一ゴースト経路の互換のため維持。
     var ghostManager: GhostManager?
+    /// 同時起動している追加ゴースト（プライマリ以外）。複数ゴースト同時実行用。
+    var additionalGhosts: [GhostManager] = []
+    /// 起動中の全ゴースト（プライマリ＋追加）。FMO 集約・一括終了に使う。
+    var allGhostManagers: [GhostManager] {
+        ([ghostManager].compactMap { $0 }) + additionalGhosts
+    }
     /// DevTools window for legacy macOS
     private var devToolsWindow: NSWindow?
     /// About window
@@ -223,7 +229,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         externalServer?.stop()
         // PLUGIN ディスパッチャ停止
         pluginDispatcher?.stop()
-        // ゴーストをシャットダウン
+        // ゴーストをシャットダウン（追加ゴースト→プライマリ）
+        terminateAllAdditionalGhosts()
         ghostManager?.shutdown()
         // 念のため残留プロセスを掃除
         ProcessKiller.killOtherOurinAndYaya()
@@ -343,20 +350,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         }
     }
 
-    /// 現在のゴースト情報から FmoGhostRecord を収集する
+    /// 起動中の全ゴースト（プライマリ＋追加）から FmoGhostRecord を収集する。
+    /// 複数ゴースト同時実行時は各ゴーストが 1 レコードを占める（FMO ID は出力側で連番付与）。
     func collectFmoRecords() -> [FmoGhostRecord] {
-        guard let gm = ghostManager, let config = gm.ghostConfig else {
-            return []
+        allGhostManagers.compactMap { gm in
+            guard let config = gm.ghostConfig else { return nil }
+            var record = FmoGhostRecord()
+            record.name = config.sakuraName
+            record.keroname = config.keroName ?? ""
+            record.path = gm.ghostURL.path
+            record.shell = gm.activeShellName
+            record.balloon = gm.balloonConfig?.name ?? ""
+            record.sakuraSurface = gm.characterViewModels[0]?.currentSurfaceID ?? 0
+            record.keroSurface = gm.characterViewModels[1]?.currentSurfaceID ?? 10
+            return record
         }
-        var record = FmoGhostRecord()
-        record.name = config.sakuraName
-        record.keroname = config.keroName ?? ""
-        record.path = gm.ghostURL.path
-        record.shell = gm.activeShellName
-        record.balloon = gm.balloonConfig?.name ?? ""
-        record.sakuraSurface = gm.characterViewModels[0]?.currentSurfaceID ?? 0
-        record.keroSurface = gm.characterViewModels[1]?.currentSurfaceID ?? 10
-        return [record]
     }
 
     /// FMO 共有メモリを現在のゴースト状態で更新する
@@ -381,6 +389,53 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         self.ghostManager = newManager
         NSLog("[runGhost] Starting GhostManager")
         newManager.start()
+    }
+
+    // MARK: - Multiple concurrent ghosts
+
+    /// 追加ゴーストを同時起動する（プライマリは置き換えない）。
+    /// EventBridge は各ゴーストを個別セッションとして登録し、NOTIFY を全ゴーストへ配信する。
+    /// SSTP は ReceiverGhostName で対象を絞り込める。
+    /// - Returns: 起動した GhostManager（既に同一パスが起動中なら既存を返す）
+    @discardableResult
+    func launchAdditionalGhost(at root: URL) -> GhostManager {
+        if let existing = allGhostManagers.first(where: { $0.ghostURL.standardizedFileURL == root.standardizedFileURL }) {
+            NSLog("[launchAdditionalGhost] already running: \(root.lastPathComponent)")
+            return existing
+        }
+        NSLog("[launchAdditionalGhost] launching: \(root.path)")
+        let manager = GhostManager(ghostURL: root)
+        additionalGhosts.append(manager)
+        manager.start()
+        NotificationCenter.default.post(name: .fmoNeedsRefresh, object: nil)
+        return manager
+    }
+
+    /// インストール済みゴースト名から追加ゴーストを起動する。
+    @discardableResult
+    func launchAdditionalGhost(named name: String) -> GhostManager? {
+        guard let item = NarRegistry.shared.installedItems(ofType: "ghost")
+            .first(where: { $0.name.caseInsensitiveCompare(name) == .orderedSame }) else {
+            NSLog("[launchAdditionalGhost] not found: \(name)")
+            return nil
+        }
+        return launchAdditionalGhost(at: item.path)
+    }
+
+    /// 追加ゴーストを終了する（プライマリは対象外）。
+    func terminateAdditionalGhost(_ manager: GhostManager) {
+        guard let idx = additionalGhosts.firstIndex(where: { $0 === manager }) else { return }
+        additionalGhosts.remove(at: idx)
+        manager.shutdown()
+        NotificationCenter.default.post(name: .fmoNeedsRefresh, object: nil)
+    }
+
+    /// すべての追加ゴーストを終了する。
+    func terminateAllAdditionalGhosts() {
+        let managers = additionalGhosts
+        additionalGhosts.removeAll()
+        for m in managers { m.shutdown() }
+        NotificationCenter.default.post(name: .fmoNeedsRefresh, object: nil)
     }
 
     /// Show DevTools window on macOS < 13

--- a/Ourin/PluginEvent/PluginEventDispatcher.swift
+++ b/Ourin/PluginEvent/PluginEventDispatcher.swift
@@ -15,6 +15,21 @@ final class PluginEventDispatcher {
     /// version 応答で交渉したプラグインごとの文字コード（複数キュー間で共有するため要ロック）
     private let charsetLock = NSLock()
     private var pluginCharsets: [Plugin: String] = [:]
+    /// XPC プロセス分離が有効な場合のクライアント（nil ならインプロセス実行）
+    private let xpcClient: PluginXpcClient?
+
+    /// プラグインへワイヤテキストを送信する。XPC 分離が有効なら別プロセスのワーカーへ、
+    /// それ以外は従来通りインプロセス（CFBundle ロード）で実行する。
+    private func transportSend(_ req: String, to plugin: Plugin) -> String {
+        if let xpc = xpcClient {
+            if let resp = xpc.send(req, bundlePath: plugin.bundle.bundleURL.path) {
+                return resp
+            }
+            logger.warning("plugin XPC send failed; bundle=\(plugin.bundle.bundleURL.lastPathComponent)")
+            return ""
+        }
+        return plugin.send(req)
+    }
 
     /// プラグインに適用する送信文字コードを取得（既定 UTF-8）
     private func charset(for plugin: Plugin) -> String {
@@ -31,6 +46,13 @@ final class PluginEventDispatcher {
     /// 初期化時にプラグインメタ情報を参照してタイマーを開始する
     init(registry: PluginRegistry) {
         self.registry = registry
+        // プロセス分離モードが有効なら XPC クライアントを用意する（既定はインプロセス）
+        if let serviceName = PluginIsolation.resolvedXpcServiceName() {
+            self.xpcClient = PluginXpcClient(serviceName: serviceName)
+            logger.info("plugin isolation=xpc service=\(serviceName)")
+        } else {
+            self.xpcClient = nil
+        }
         // 各プラグイン用の直列キューを生成
         for plugin in registry.plugins {
             queues[plugin] = DispatchQueue(label: "plugin.queue." + plugin.bundle.bundleURL.lastPathComponent)
@@ -63,9 +85,9 @@ final class PluginEventDispatcher {
             guard let q = queues[plugin] else { continue }
             // version 交渉で得た文字コードを Charset ヘッダへ反映する
             let req = PluginFrame(id: id, references: refs, charset: charset(for: plugin), notify: notify).build()
-            q.async { [logger, id, req, plugin] in
+            q.async { [weak self, logger, id, req, plugin] in
                 let start = Date()
-                let _ = plugin.send(req)
+                _ = self?.transportSend(req, to: plugin)
                 let elapsed = Date().timeIntervalSince(start)
                 logger.debug("ID \(id) to \(plugin.bundle.bundleURL.lastPathComponent) (\(elapsed)s)")
                 if elapsed > 3 {
@@ -80,7 +102,7 @@ final class PluginEventDispatcher {
         for plugin in registry.plugins {
             let req = PluginFrame(id: "version").build()
             queues[plugin]?.async { [weak self, logger, req, plugin] in
-                let resp = plugin.send(req)
+                let resp = self?.transportSend(req, to: plugin) ?? ""
                 let name = plugin.bundle.bundleURL.lastPathComponent
                 // 応答の Charset ヘッダを以降の通信へ適用する(PLUGIN_EVENT/2.0M §4.1)
                 if let parsed = try? PluginProtocolParser.parseResponse(resp) {

--- a/Ourin/PluginHost/Plugin.swift
+++ b/Ourin/PluginHost/Plugin.swift
@@ -28,8 +28,9 @@ public struct Plugin: Hashable {
             throw NSError(domain: "Plugin", code: -2, userInfo: [NSLocalizedDescriptionKey: "request not found"])
         }
         self.request = req
-        self.load = sym("load")
-        self.unload = sym("unload")
+        // ukagaka DLL 規約: `loadu` は UTF-8 パス版 load。存在すれば優先（macOS のパスは UTF-8）。
+        self.load = sym("loadu") ?? sym("load")
+        self.unload = sym("unloadu") ?? sym("unload")
     }
 
     /// Send raw wire text to plugin and return response string (UTF-8)

--- a/Ourin/PluginHost/PluginXpcBackend.swift
+++ b/Ourin/PluginHost/PluginXpcBackend.swift
@@ -1,0 +1,80 @@
+import Foundation
+import OSLog
+
+/// プラグインを別プロセス(XPC サービス)で実行するためのワーカープロトコル。
+///
+/// SHIORI の `OurinShioriXPC` と同じ設計。ワーカー側は `bundlePath` の `.plugin`/`.bundle` を
+/// 自プロセスでロードし、PLUGIN/2.0M のワイヤテキスト(`request`)を受けて応答テキストを返す。
+/// `reply` の Data が nil の場合は失敗（ホスト側はインプロセスにフォールバックしない＝XPC固定）。
+@objc public protocol OurinPluginXPC {
+    func executePlugin(_ request: Data, bundlePath: String, withReply reply: @escaping (Data?) -> Void)
+}
+
+/// プラグイン用 XPC クライアント。`machServiceName` のワーカーへ `Data->Data` で橋渡しする。
+/// 同期 API（`send`）で、内部はセマフォ＋タイムアウト（SHIORI XpcBackend と同方式）。
+public final class PluginXpcClient {
+    private let connection: NSXPCConnection
+    private let timeout: TimeInterval
+    private let logger = CompatLogger(subsystem: "Ourin", category: "PluginXPC")
+
+    public init(serviceName: String, timeout: TimeInterval = 5.0) {
+        self.connection = NSXPCConnection(machServiceName: serviceName, options: [])
+        self.connection.remoteObjectInterface = NSXPCInterface(with: OurinPluginXPC.self)
+        self.connection.resume()
+        self.timeout = timeout
+    }
+
+    deinit { connection.invalidate() }
+
+    /// ワイヤテキストをワーカーへ送り、応答テキストを返す（失敗時 nil）。
+    /// - Parameters:
+    ///   - text: PLUGIN/2.0M リクエスト本文
+    ///   - bundlePath: ロード対象プラグインの bundle パス
+    public func send(_ text: String, bundlePath: String) -> String? {
+        let requestData = Data(text.utf8)
+        let sem = DispatchSemaphore(value: 0)
+        var responseData: Data?
+        var connectionError: Error?
+
+        guard let proxy = connection.remoteObjectProxyWithErrorHandler({ error in
+            connectionError = error
+            sem.signal()
+        }) as? OurinPluginXPC else {
+            logger.fault("failed to create plugin XPC proxy")
+            return nil
+        }
+
+        proxy.executePlugin(requestData, bundlePath: bundlePath) { data in
+            responseData = data
+            sem.signal()
+        }
+
+        if sem.wait(timeout: .now() + timeout) == .timedOut {
+            logger.fault("plugin XPC request timed out")
+            return nil
+        }
+        if let connectionError {
+            logger.fault("plugin XPC error: \(connectionError.localizedDescription)")
+            return nil
+        }
+        guard let responseData else { return nil }
+        return String(data: responseData, encoding: .utf8)
+    }
+}
+
+/// プラグインのプロセス分離モード解決（環境変数ベース。SHIORI の resolvedXpcServiceName と同方針）。
+public enum PluginIsolation {
+    /// XPC 分離を使う場合の mach サービス名を返す。インプロセス実行時は nil。
+    /// - `OURIN_PLUGIN_XPC_SERVICE` を最優先。
+    /// - `OURIN_PLUGIN_ISOLATION_MODE=xpc` の場合は既定名 `jp.ourin.plugin`。
+    public static func resolvedXpcServiceName(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        if let explicit = environment["OURIN_PLUGIN_XPC_SERVICE"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !explicit.isEmpty {
+            return explicit
+        }
+        if environment["OURIN_PLUGIN_ISOLATION_MODE"]?.lowercased() == "xpc" {
+            return "jp.ourin.plugin"
+        }
+        return nil
+    }
+}

--- a/Ourin/Property/BalloonPropertyProvider.swift
+++ b/Ourin/Property/BalloonPropertyProvider.swift
@@ -84,14 +84,15 @@ final class BalloonPropertyProvider: PropertyProvider {
         // balloonlist(name/path).property
         if let (identifier, prop) = parseNamedAccess(key: key) {
             if let balloon = findBalloon(by: identifier) {
-                return getBalloonProperty(balloon, prop: prop)
+                let idx = balloons.firstIndex { $0.name == balloon.name && $0.path == balloon.path }
+                return getBalloonProperty(balloon, prop: prop, index: idx)
             }
         }
 
         // balloonlist.index(n).property
         if let (index, prop) = parseIndex(key: key) {
             guard balloons.indices.contains(index) else { return nil }
-            return getBalloonProperty(balloons[index], prop: prop)
+            return getBalloonProperty(balloons[index], prop: prop, index: index)
         }
 
         return nil
@@ -112,7 +113,7 @@ final class BalloonPropertyProvider: PropertyProvider {
 
     // MARK: - Helpers
 
-    private func getBalloonProperty(_ balloon: Balloon, prop: String) -> String? {
+    private func getBalloonProperty(_ balloon: Balloon, prop: String, index: Int? = nil) -> String? {
         switch prop {
         case "name":
             return balloon.name
@@ -122,6 +123,8 @@ final class BalloonPropertyProvider: PropertyProvider {
             return balloon.craftmanw
         case "craftmanurl":
             return balloon.craftmanurl
+        case "index":
+            return index.map(String.init)
         default:
             return nil
         }

--- a/Ourin/Property/GhostPropertyProvider.swift
+++ b/Ourin/Property/GhostPropertyProvider.swift
@@ -12,11 +12,19 @@ public struct Ghost {
     public let homeurl: String
     public var username: String?
     public var configuration: GhostConfiguration?
+    // PROPERTY/1.0M §4.12 汎用プロパティ名（未設定時は空 → nil 相当）
+    public var thumbnail: String
+    public var updateResult: String
+    public var updateTime: String
+    /// `shiori.<変数名>` で参照する SHIORI 由来の値（必要に応じて外部から設定）
+    public var shioriVars: [String: String]
 
     public init(name: String, sakuraname: String = "", keroname: String = "",
                 craftmanw: String = "", craftmanurl: String = "",
                 path: String, icon: String = "", homeurl: String = "", username: String? = nil,
-                configuration: GhostConfiguration? = nil) {
+                configuration: GhostConfiguration? = nil,
+                thumbnail: String = "", updateResult: String = "", updateTime: String = "",
+                shioriVars: [String: String] = [:]) {
         self.name = name
         self.sakuraname = sakuraname.isEmpty ? name : sakuraname
         self.keroname = keroname
@@ -27,6 +35,10 @@ public struct Ghost {
         self.homeurl = homeurl
         self.username = username
         self.configuration = configuration
+        self.thumbnail = thumbnail
+        self.updateResult = updateResult
+        self.updateTime = updateTime
+        self.shioriVars = shioriVars
     }
 
     /// Initialize from a GhostConfiguration.
@@ -41,6 +53,10 @@ public struct Ghost {
         self.homeurl = config.homeurl ?? ""
         self.username = username
         self.configuration = config
+        self.thumbnail = ""
+        self.updateResult = ""
+        self.updateTime = ""
+        self.shioriVars = [:]
     }
 }
 
@@ -76,10 +92,16 @@ final class GhostPropertyProvider: PropertyProvider {
     private var scopeData: [Int: ScopeData]
     private var mouseCursor: [String: String]
     private var balloonMouseCursor: [String: String]
-    private var serikoCursor: [Int: [String: String]]
+    // SERIKO カーソルは scope → リスト種別(mouseup/down/hover/wheel) → 名前 → パス
+    private var serikoCursor: [Int: [String: [String: String]]]
     private var serikoTooltips: [Int: [String: String]]
+
+    /// PROPERTY/1.0M の `mouse????list` 4種（当たり判定リスト）
+    private static let cursorListKinds = ["mouseuplist", "mousedownlist", "mousehoverlist", "mousewheellist"]
     private var serikoSurfaceListAll: String
     private var serikoSurfaceListDefined: String
+    /// `(sakura|kero|char*).bind.menu` のメニュー表示状態（currentghost の runtime 状態、SET 可）
+    private var bindMenus: [String: String] = [:]
 
     struct ScopeData {
         var surfaceNum: Int
@@ -97,7 +119,7 @@ final class GhostPropertyProvider: PropertyProvider {
          scopeData: [Int: ScopeData] = [:],
          mouseCursor: [String: String] = [:],
          balloonMouseCursor: [String: String] = [:],
-         serikoCursor: [Int: [String: String]] = [:],
+         serikoCursor: [Int: [String: [String: String]]] = [:],
          serikoTooltips: [Int: [String: String]] = [:],
          serikoSurfaceListAll: String = "",
          serikoSurfaceListDefined: String = "") {
@@ -159,6 +181,15 @@ final class GhostPropertyProvider: PropertyProvider {
             return setSerikoCursor(key: key, value: value)
         }
 
+        // (sakura|kero|char*).bind.menu の表示状態（SET 有効：PROPERTY/1.0M §5）
+        if key.hasSuffix(".bind.menu") {
+            let scope = String(key.dropLast(".bind.menu".count))
+            if scope == "sakura" || scope == "kero" || scope.hasPrefix("char") {
+                bindMenus[scope] = value
+                return true
+            }
+        }
+
         return false
     }
 
@@ -176,7 +207,9 @@ final class GhostPropertyProvider: PropertyProvider {
             "mousecursor.arrow",
             "balloon.mousecursor.text",
             "balloon.mousecursor.wait",
-            "balloon.mousecursor.arrow"
+            "balloon.mousecursor.arrow",
+            "sakura.bind.menu",
+            "kero.bind.menu"
         ])
         return props
     }
@@ -190,14 +223,15 @@ final class GhostPropertyProvider: PropertyProvider {
         // ghostlist(name/sakuraname/path).property
         if let (identifier, prop) = parseNamedAccess(key: key, prefix: "") {
             if let g = findGhost(by: identifier) {
-                return getGhostProperty(g, prop: prop)
+                let idx = ghosts.firstIndex { $0.name == g.name && $0.path == g.path }
+                return getGhostProperty(g, prop: prop, index: idx)
             }
         }
 
         // ghostlist.index(n).property
         if let (index, prop) = parseIndex(key: key) {
             guard ghosts.indices.contains(index) else { return nil }
-            return getGhostProperty(ghosts[index], prop: prop)
+            return getGhostProperty(ghosts[index], prop: prop, index: index)
         }
 
         return nil
@@ -212,14 +246,15 @@ final class GhostPropertyProvider: PropertyProvider {
         // activeghostlist(name/sakuraname/path).property
         if let (identifier, prop) = parseNamedAccess(key: key, prefix: "") {
             if let g = findActiveGhost(by: identifier) {
-                return getGhostProperty(g, prop: prop)
+                let idx = activeIndices.firstIndex { ghosts.indices.contains($0) && ghosts[$0].name == g.name && ghosts[$0].path == g.path }
+                return getGhostProperty(g, prop: prop, index: idx)
             }
         }
 
         // activeghostlist.index(n).property
         if let (index, prop) = parseIndex(key: key) {
             guard activeIndices.indices.contains(index) else { return nil }
-            return getGhostProperty(ghosts[activeIndices[index]], prop: prop)
+            return getGhostProperty(ghosts[activeIndices[index]], prop: prop, index: index)
         }
 
         return nil
@@ -236,8 +271,8 @@ final class GhostPropertyProvider: PropertyProvider {
         }
         let g = ghosts[idx]
 
-        // Simple properties
-        if let value = getGhostProperty(g, prop: key) {
+        // Simple properties（汎用名・index・shiori.<var>・*.bind.menu を含む）
+        if let value = getGhostProperty(g, prop: key, index: idx) {
             return value
         }
 
@@ -341,7 +376,9 @@ final class GhostPropertyProvider: PropertyProvider {
 
     // MARK: - Helpers
 
-    private func getGhostProperty(_ ghost: Ghost, prop: String) -> String? {
+    /// 汎用プロパティ名を解決する（PROPERTY/1.0M §4.12）。
+    /// - Parameter index: `index` プロパティ用のリスト内順位（不明なら nil）。
+    private func getGhostProperty(_ ghost: Ghost, prop: String, index: Int? = nil) -> String? {
         switch prop {
         case "name":
             return ghost.name
@@ -361,7 +398,25 @@ final class GhostPropertyProvider: PropertyProvider {
             return ghost.homeurl
         case "username":
             return ghost.username
+        case "thumbnail":
+            return ghost.thumbnail.isEmpty ? nil : ghost.thumbnail
+        case "update_result":
+            return ghost.updateResult.isEmpty ? nil : ghost.updateResult
+        case "update_time":
+            return ghost.updateTime.isEmpty ? nil : ghost.updateTime
+        case "index":
+            return index.map(String.init)
         default:
+            // shiori.<変数名>
+            if prop.hasPrefix("shiori.") {
+                let varName = String(prop.dropFirst("shiori.".count))
+                return ghost.shioriVars[varName]
+            }
+            // (sakura|kero|char*).bind.menu : currentghost の runtime 状態（bindMenus）から解決
+            if prop.hasSuffix(".bind.menu") {
+                let scope = String(prop.dropLast(".bind.menu".count))
+                return bindMenus[scope]
+            }
             return nil
         }
     }
@@ -499,16 +554,21 @@ final class GhostPropertyProvider: PropertyProvider {
     }
 
     private func getSerikoCursor(key: String) -> String? {
-        // seriko.cursor.scope(ID).mouselist(...)
+        // seriko.cursor.scope(ID).mouse????list(...)  (???? = up / down / hover / wheel)
         guard let (scopeID, scopeTail) = parseScopePrefix(key: key, prefix: "seriko.cursor.scope") else {
             return nil
         }
-        let list = serikoCursor[scopeID] ?? [:]
-        if scopeTail == "mouselist.count" {
+        guard let listName = Self.cursorListKinds.first(where: {
+            scopeTail == "\($0).count" || scopeTail.hasPrefix("\($0)(") || scopeTail.hasPrefix("\($0).index(")
+        }) else {
+            return nil
+        }
+        let list = serikoCursor[scopeID]?[listName] ?? [:]
+        if scopeTail == "\(listName).count" {
             return String(list.count)
         }
 
-        if let (name, prop) = parseNamedAccess(key: scopeTail, prefix: "mouselist") {
+        if let (name, prop) = parseNamedAccess(key: scopeTail, prefix: listName) {
             switch prop {
             case "path":
                 return list[name]
@@ -519,8 +579,8 @@ final class GhostPropertyProvider: PropertyProvider {
             }
         }
 
-        if scopeTail.hasPrefix("mouselist.index(") {
-            let sub = String(scopeTail.dropFirst("mouselist.".count))
+        if scopeTail.hasPrefix("\(listName).index(") {
+            let sub = String(scopeTail.dropFirst("\(listName).".count))
             if let (idx, prop) = parseIndex(key: sub) {
                 let names = list.keys.sorted()
                 guard names.indices.contains(idx) else { return nil }
@@ -553,16 +613,26 @@ final class GhostPropertyProvider: PropertyProvider {
         guard let (scopeID, scopeTail) = parseScopePrefix(key: key, prefix: "seriko.cursor.scope") else {
             return false
         }
-        guard let (name, prop) = parseNamedAccess(key: scopeTail, prefix: "mouselist"), prop == "path" else {
+        guard let listName = Self.cursorListKinds.first(where: { scopeTail.hasPrefix("\($0)(") }) else {
             return false
         }
-        var cursors = serikoCursor[scopeID] ?? [:]
+        guard let (name, prop) = parseNamedAccess(key: scopeTail, prefix: listName), prop == "path" else {
+            return false
+        }
+        var byKind = serikoCursor[scopeID] ?? [:]
+        var cursors = byKind[listName] ?? [:]
         if value.isEmpty {
             cursors.removeValue(forKey: name)
         } else {
             cursors[name] = value
         }
-        serikoCursor[scopeID] = cursors
+        // 空になった種別は削除し、scope ごと空なら除去（PROPERTY/1.0M: 空文字で定義削除）
+        if cursors.isEmpty {
+            byKind.removeValue(forKey: listName)
+        } else {
+            byKind[listName] = cursors
+        }
+        serikoCursor[scopeID] = byKind.isEmpty ? nil : byKind
         return true
     }
 

--- a/Ourin/Property/HeadlinePropertyProvider.swift
+++ b/Ourin/Property/HeadlinePropertyProvider.swift
@@ -31,14 +31,15 @@ final class HeadlinePropertyProvider: PropertyProvider {
         // headlinelist(name/path).property
         if let (identifier, prop) = parseNamedAccess(key: key) {
             if let headline = findHeadline(by: identifier) {
-                return getHeadlineProperty(headline, prop: prop)
+                let idx = headlines.firstIndex { $0.name == headline.name && $0.path == headline.path }
+                return getHeadlineProperty(headline, prop: prop, index: idx)
             }
         }
 
         // headlinelist.index(n).property
         if let (index, prop) = parseIndex(key: key) {
             guard headlines.indices.contains(index) else { return nil }
-            return getHeadlineProperty(headlines[index], prop: prop)
+            return getHeadlineProperty(headlines[index], prop: prop, index: index)
         }
 
         return nil
@@ -46,7 +47,7 @@ final class HeadlinePropertyProvider: PropertyProvider {
 
     // MARK: - Helpers
 
-    private func getHeadlineProperty(_ headline: Headline, prop: String) -> String? {
+    private func getHeadlineProperty(_ headline: Headline, prop: String, index: Int? = nil) -> String? {
         switch prop {
         case "name":
             return headline.name
@@ -56,6 +57,8 @@ final class HeadlinePropertyProvider: PropertyProvider {
             return headline.craftmanw
         case "craftmanurl":
             return headline.craftmanurl
+        case "index":
+            return index.map(String.init)
         default:
             return nil
         }

--- a/Ourin/Property/PluginPropertyProvider.swift
+++ b/Ourin/Property/PluginPropertyProvider.swift
@@ -33,14 +33,15 @@ final class PluginPropertyProvider: PropertyProvider {
         // pluginlist(name/path/id).property
         if let (identifier, prop) = parseNamedAccess(key: key) {
             if let plugin = findPlugin(by: identifier) {
-                return getPluginProperty(plugin, prop: prop)
+                let idx = plugins.firstIndex { $0.id == plugin.id && $0.path == plugin.path }
+                return getPluginProperty(plugin, prop: prop, index: idx)
             }
         }
 
         // pluginlist.index(n).property
         if let (index, prop) = parseIndex(key: key) {
             guard plugins.indices.contains(index) else { return nil }
-            return getPluginProperty(plugins[index], prop: prop)
+            return getPluginProperty(plugins[index], prop: prop, index: index)
         }
 
         return nil
@@ -48,7 +49,7 @@ final class PluginPropertyProvider: PropertyProvider {
 
     // MARK: - Helpers
 
-    private func getPluginProperty(_ plugin: PropertyPlugin, prop: String) -> String? {
+    private func getPluginProperty(_ plugin: PropertyPlugin, prop: String, index: Int? = nil) -> String? {
         switch prop {
         case "name":
             return plugin.name
@@ -60,6 +61,8 @@ final class PluginPropertyProvider: PropertyProvider {
             return plugin.craftmanw
         case "craftmanurl":
             return plugin.craftmanurl
+        case "index":
+            return index.map(String.init)
         default:
             return nil
         }

--- a/Ourin/ResourceBridge/ResourceBridge.swift
+++ b/Ourin/ResourceBridge/ResourceBridge.swift
@@ -22,6 +22,10 @@ public final class ResourceBridge {
         var time: Date
     }
     private var cache: [String: Entry] = [:]
+    /// SET で上書きされたリソース値（SHIORI 問い合わせより優先。空文字は「定義削除」を表す）。
+    private var overrides: [String: String] = [:]
+    /// cache/overrides の同時アクセス保護
+    private let lock = NSLock()
     /// キャッシュ保持時間（秒）
     private let ttl: TimeInterval = 5
     /// ロガー
@@ -30,28 +34,57 @@ public final class ResourceBridge {
     /// Get resource value for given key via SHIORI. Uses cache if valid.
     public func get(_ key: String) -> String? {
         let now = Date()
+        lock.lock()
+        // SET 上書きが最優先（空文字は定義削除＝nil 相当）。
+        if let overridden = overrides[key] {
+            lock.unlock()
+            return overridden.isEmpty ? nil : overridden
+        }
         if let entry = cache[key], let cachedValue = entry.value,
            now.timeIntervalSince(entry.time) < ttl {
+            lock.unlock()
             return cachedValue
         }
+        lock.unlock()
+
         let value = query(key: key)
+        lock.lock()
         if let value = value {
             cache[key] = Entry(value: value, time: now)
         } else {
             cache.removeValue(forKey: key)
         }
+        lock.unlock()
         logger.debug("query \(key) -> \(value ?? "nil")")
         return value
     }
 
-    /// Force invalidate all cached values
-    public func invalidateAll() {
-        cache.removeAll()
+    /// リソース値を SET（上書き）する。以降の `get` は SHIORI を介さず上書き値を返す。
+    /// 空文字を渡すと「定義削除」（`get` は nil を返す）。UKADOC のリソース SET 相当。
+    public func set(_ key: String, value: String) {
+        lock.lock()
+        overrides[key] = value
+        cache.removeValue(forKey: key)
+        lock.unlock()
+        logger.debug("set \(key) = \(value)")
     }
 
-    /// 指定キーのみキャッシュを無効化する
+    /// SET 上書きを解除し、以降は SHIORI 問い合わせに戻す。
+    public func clearOverride(_ key: String) {
+        lock.lock()
+        overrides.removeValue(forKey: key)
+        cache.removeValue(forKey: key)
+        lock.unlock()
+    }
+
+    /// Force invalidate all cached values（上書きは保持する）
+    public func invalidateAll() {
+        lock.lock(); cache.removeAll(); lock.unlock()
+    }
+
+    /// 指定キーのみキャッシュを無効化する（上書きは保持する）
     public func invalidate(keys: [String]) {
-        for k in keys { cache.removeValue(forKey: k) }
+        lock.lock(); for k in keys { cache.removeValue(forKey: k) }; lock.unlock()
     }
 
     // MARK: - Parsing helpers

--- a/Ourin/SHIORIEvents/EventBridge.swift
+++ b/Ourin/SHIORIEvents/EventBridge.swift
@@ -3,6 +3,31 @@
 import AppKit
 import UniformTypeIdentifiers
 
+/// SHIORI へ送るイベントのセキュリティ文脈。
+/// システム由来の内部イベントは `.local`、外部SSTP等に由来する場合は `.external(origin:)`。
+/// SHIORI 側が `SecurityLevel` / `SecurityOrigin` で発生源を判別できるようにする（UKADOC）。
+struct ShioriSecurityContext: Equatable {
+    /// "local" または "external"
+    let level: String
+    /// SecurityOrigin（URL等）。無い場合は nil。
+    let origin: String?
+
+    /// 内部システムイベント既定（ローカル）
+    static let local = ShioriSecurityContext(level: "local", origin: nil)
+
+    /// 外部由来（必要なら origin を付与）
+    static func external(origin: String? = nil) -> ShioriSecurityContext {
+        ShioriSecurityContext(level: "external", origin: origin)
+    }
+
+    /// SHIORI リクエストヘッダへ差し込む辞書を返す（Charset/Sender 込み）
+    func shioriHeaders() -> [String: String] {
+        var h: [String: String] = ["Charset": "UTF-8", "Sender": "Ourin", "SecurityLevel": level]
+        if let origin, !origin.isEmpty { h["SecurityOrigin"] = origin }
+        return h
+    }
+}
+
 final class EventBridge {
     static let shared = EventBridge()
     private init() {}
@@ -12,8 +37,8 @@ final class EventBridge {
 
     // Queue for NOTIFY events that occur when autoEvents are disabled
     private enum QueuedNotify {
-        case standard(id: EventID, params: [String: String])
-        case custom(eventName: String, params: [String: String], ignoreResponseScript: Bool)
+        case standard(id: EventID, params: [String: String], security: ShioriSecurityContext)
+        case custom(eventName: String, params: [String: String], ignoreResponseScript: Bool, security: ShioriSecurityContext)
     }
     private var pendingNotifies: [QueuedNotify] = []
 
@@ -149,10 +174,10 @@ final class EventBridge {
         Log.debug("[EventBridge] Flushing \(pendingNotifies.count) queued NOTIFY events")
         for queued in pendingNotifies {
             switch queued {
-            case .standard(let id, let params):
-                broadcastNotifyImmediate(id: id, params: params)
-            case .custom(let eventName, let params, let ignoreResponseScript):
-                broadcastNotifyCustomImmediate(eventName: eventName, params: params, ignoreResponseScript: ignoreResponseScript)
+            case .standard(let id, let params, let security):
+                broadcastNotifyImmediate(id: id, params: params, security: security)
+            case .custom(let eventName, let params, let ignoreResponseScript, let security):
+                broadcastNotifyCustomImmediate(eventName: eventName, params: params, ignoreResponseScript: ignoreResponseScript, security: security)
             }
         }
         pendingNotifies.removeAll()
@@ -172,8 +197,9 @@ final class EventBridge {
     }
 
     /// Public helper to send a NOTIFY event by ID
-    func notify(_ id: EventID, params: [String:String] = [:]) {
-        broadcastNotify(id: id, params: params)
+    /// - Parameter security: 発生源のセキュリティ文脈（既定: 内部システム = local）
+    func notify(_ id: EventID, params: [String:String] = [:], security: ShioriSecurityContext = .local) {
+        broadcastNotify(id: id, params: params, security: security)
     }
 
     /// 外部SSTP（SEND の Script ヘッダ等）から、登録済みゴーストのバルーンでスクリプトを再生する。
@@ -214,32 +240,33 @@ final class EventBridge {
     }
 
     /// Public helper to send a NOTIFY event by custom name (for \![raise,...])
-    func notifyCustom(_ eventName: String, params: [String:String] = [:], ignoreResponseScript: Bool = false) {
-        broadcastNotifyCustom(eventName: eventName, params: params, ignoreResponseScript: ignoreResponseScript)
+    /// - Parameter security: 発生源のセキュリティ文脈（既定: 内部 = local）
+    func notifyCustom(_ eventName: String, params: [String:String] = [:], ignoreResponseScript: Bool = false, security: ShioriSecurityContext = .local) {
+        broadcastNotifyCustom(eventName: eventName, params: params, ignoreResponseScript: ignoreResponseScript, security: security)
     }
 
     // Broadcast a NOTIFY to all registered sessions
     // If auto events are disabled, queue the event for later delivery
-    private func broadcastNotify(id: EventID, params: [String:String]) {
+    private func broadcastNotify(id: EventID, params: [String:String], security: ShioriSecurityContext = .local) {
         if !autoEventsEnabled {
             // Queue this event for later when auto events are enabled
-            pendingNotifies.append(.standard(id: id, params: params))
+            pendingNotifies.append(.standard(id: id, params: params, security: security))
             Log.debug("[EventBridge] Queued NOTIFY event: \(id.rawValue) (auto events disabled)")
             return
         }
-        broadcastNotifyImmediate(id: id, params: params)
+        broadcastNotifyImmediate(id: id, params: params, security: security)
     }
 
     // Broadcast a custom NOTIFY to all registered sessions
     // If auto events are disabled, queue the event for later delivery
-    private func broadcastNotifyCustom(eventName: String, params: [String:String], ignoreResponseScript: Bool) {
+    private func broadcastNotifyCustom(eventName: String, params: [String:String], ignoreResponseScript: Bool, security: ShioriSecurityContext = .local) {
         if !autoEventsEnabled {
             // Queue this event for later when auto events are enabled
-            pendingNotifies.append(.custom(eventName: eventName, params: params, ignoreResponseScript: ignoreResponseScript))
+            pendingNotifies.append(.custom(eventName: eventName, params: params, ignoreResponseScript: ignoreResponseScript, security: security))
             Log.debug("[EventBridge] Queued custom NOTIFY event: \(eventName) (auto events disabled)")
             return
         }
-        broadcastNotifyCustomImmediate(eventName: eventName, params: params, ignoreResponseScript: ignoreResponseScript)
+        broadcastNotifyCustomImmediate(eventName: eventName, params: params, ignoreResponseScript: ignoreResponseScript, security: security)
     }
 
     // 時刻系イベント: Reference3（トーク再生可否）に応じて GET / NOTIFY を切り替える（UKADOC）
@@ -256,7 +283,7 @@ final class EventBridge {
     ]
 
     // Immediately broadcast a NOTIFY to all registered sessions (bypassing queue)
-    private func broadcastNotifyImmediate(id: EventID, params: [String:String]) {
+    private func broadcastNotifyImmediate(id: EventID, params: [String:String], security: ShioriSecurityContext = .local) {
         // Save character names on OnNotifySelfInfo
         if id == .OnNotifySelfInfo {
             let sakuraName = params["Reference0"] ?? params["Reference1"] ?? ""
@@ -278,7 +305,7 @@ final class EventBridge {
                 }
                 if cantalk {
                     // 再生可能: GET で送り、返値スクリプトを再生する（ランダムトークの基本動線）
-                    let script = s.dispatcher.sendGet(id: id, params: p)
+                    let script = s.dispatcher.sendGet(id: id, params: p, security: security)
                     let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
                     if !trimmed.isEmpty {
                         let gm = s.ghostManager
@@ -286,7 +313,7 @@ final class EventBridge {
                     }
                 } else {
                     // 再生不能: NOTIFY で送り、返値は無視する
-                    s.dispatcher.sendNotify(id: id, params: p, ignoreResponseScript: true)
+                    s.dispatcher.sendNotify(id: id, params: p, ignoreResponseScript: true, security: security)
                 }
             }
             return
@@ -297,14 +324,14 @@ final class EventBridge {
             if Self.mouseEvents.contains(id), s.ghostManager?.timeCriticalActive == true {
                 continue
             }
-            s.dispatcher.sendNotify(id: id, params: params)
+            s.dispatcher.sendNotify(id: id, params: params, security: security)
         }
     }
 
     // Immediately broadcast a custom NOTIFY to all registered sessions (bypassing queue)
-    private func broadcastNotifyCustomImmediate(eventName: String, params: [String:String], ignoreResponseScript: Bool) {
+    private func broadcastNotifyCustomImmediate(eventName: String, params: [String:String], ignoreResponseScript: Bool, security: ShioriSecurityContext = .local) {
         for (_, s) in sessions {
-            s.dispatcher.sendNotifyCustom(eventName: eventName, params: params, ignoreResponseScript: ignoreResponseScript)
+            s.dispatcher.sendNotifyCustom(eventName: eventName, params: params, ignoreResponseScript: ignoreResponseScript, security: security)
         }
     }
 }
@@ -388,18 +415,18 @@ final class ShioriDispatcher {
 
     /// BridgeToSHIORI 経由で SHIORI モジュールへ NOTIFY を送出する
     /// - Parameter ignoreResponseScript: true の場合、返値スクリプトを再生しない（cantalk=0 の時刻系イベント等）
-    func sendNotify(id: EventID, params: [String:String], ignoreResponseScript: Bool = false) {
+    func sendNotify(id: EventID, params: [String:String], ignoreResponseScript: Bool = false, security: ShioriSecurityContext = .local) {
         let req = buildRequest(method: "NOTIFY", id: id.rawValue, params: params)
         let refs = orderedRefs(from: params)
         var script: String = ""
 
+        let hdrs = security.shioriHeaders()
         if let ya = yayaAdapter {
-            let hdrs: [String: String] = ["Charset": "UTF-8", "SecurityLevel": "local", "Sender": "Ourin"]
             if let res = ya.request(method: "NOTIFY", id: id.rawValue, headers: hdrs, refs: refs, timeout: 2.0), res.ok, let val = res.value {
                 script = val
             }
         } else {
-            script = BridgeToSHIORI.handle(event: id.rawValue, references: refs)
+            script = BridgeToSHIORI.handle(event: id.rawValue, references: refs, headers: hdrs)
         }
         Log.debug("[Ourin] NOTIFY built:\n\(req)")
         if ignoreResponseScript { return }
@@ -410,18 +437,18 @@ final class ShioriDispatcher {
     }
 
     /// BridgeToSHIORI 経由で SHIORI モジュールへカスタム名の NOTIFY を送出する（\![raise,...]用）
-    func sendNotifyCustom(eventName: String, params: [String:String], ignoreResponseScript: Bool = false) {
+    func sendNotifyCustom(eventName: String, params: [String:String], ignoreResponseScript: Bool = false, security: ShioriSecurityContext = .local) {
         let req = buildRequest(method: "NOTIFY", id: eventName, params: params)
         let refs = orderedRefs(from: params)
         var script: String = ""
 
-        let hdrs: [String: String] = ["Charset": "UTF-8", "SecurityLevel": "local", "Sender": "Ourin"]
+        let hdrs = security.shioriHeaders()
         if let ya = yayaAdapter {
             if let res = ya.request(method: "NOTIFY", id: eventName, headers: hdrs, refs: refs, timeout: 2.0), res.ok, let val = res.value {
                 script = val
             }
         } else {
-            script = BridgeToSHIORI.handle(event: eventName, references: refs)
+            script = BridgeToSHIORI.handle(event: eventName, references: refs, headers: hdrs)
         }
         Log.debug("[Ourin] Custom NOTIFY built:\n\(req)")
         if ignoreResponseScript {
@@ -434,17 +461,17 @@ final class ShioriDispatcher {
     }
 
     /// BridgeToSHIORI 経由で SHIORI モジュールへ GET を送出し応答を返す
-    func sendGet(id: EventID, params: [String:String]) -> String {
+    func sendGet(id: EventID, params: [String:String], security: ShioriSecurityContext = .local) -> String {
         let req = buildRequest(method: "GET", id: id.rawValue, params: params)
         let refs = orderedRefs(from: params)
-        let hdrs: [String: String] = ["Charset": "UTF-8", "SecurityLevel": "local", "Sender": "Ourin"]
+        let hdrs = security.shioriHeaders()
         var res = ""
         if let ya = yayaAdapter {
             if let r = ya.request(method: "GET", id: id.rawValue, headers: hdrs, refs: refs, timeout: 3.0), r.ok, let val = r.value {
                 res = val
             }
         } else {
-            res = BridgeToSHIORI.handle(event: id.rawValue, references: refs)
+            res = BridgeToSHIORI.handle(event: id.rawValue, references: refs, headers: hdrs)
         }
         Log.debug("[Ourin] GET built:\n\(req)")
         return res

--- a/Ourin/SaoriHost/SaoriLoader.swift
+++ b/Ourin/SaoriHost/SaoriLoader.swift
@@ -57,8 +57,10 @@ public final class SaoriLoader {
         }
 
         requestFn = loadSymbol(["request", "saori_request"], as: SaoriRequestFn.self)
-        loadFn = loadSymbol(["load", "saori_load"], as: SaoriLoadFn.self)
-        unloadFn = loadSymbol(["unload", "saori_unload"], as: SaoriUnloadFn.self)
+        // ukagaka DLL 規約: `loadu` は UTF-8 パス版の load エントリ。存在すれば優先する
+        // （macOS のパスは UTF-8 なので withCString はそのまま UTF-8 を渡せる）。
+        loadFn = loadSymbol(["loadu", "saori_loadu", "load", "saori_load"], as: SaoriLoadFn.self)
+        unloadFn = loadSymbol(["unloadu", "unload", "saori_unloadu", "saori_unload"], as: SaoriUnloadFn.self)
 
         guard requestFn != nil else {
             closeHandle()

--- a/Ourin/USL/ShioriLoader.swift
+++ b/Ourin/USL/ShioriLoader.swift
@@ -461,14 +461,20 @@ final class DylibBackend: ShioriBackend {
             throw ShioriLoaderError.openFailed(detail)
         }
         handle = h
-        func loadSymbol<T>(_ name: String, as type: T.Type) -> T? {
-            guard let sym = dlsym(h, name) else { return nil }
-            return unsafeBitCast(sym, to: type)
+        func loadSymbol<T>(_ names: [String], as type: T.Type) -> T? {
+            for name in names {
+                if let sym = dlsym(h, name) {
+                    return unsafeBitCast(sym, to: type)
+                }
+            }
+            return nil
         }
-        loadFn = loadSymbol("shiori_load", as: ShioriLoad.self)
-        requestFn = loadSymbol("shiori_request", as: ShioriRequest.self)
-        unloadFn = loadSymbol("shiori_unload", as: ShioriUnload.self)
-        freeFn = loadSymbol("shiori_free", as: ShioriFree.self)
+        // 汎用 dylib 規約に対応: `shiori_` 接頭辞付き・無印（Windows 由来の load/unload/request）・
+        // および UTF-8 パス版 `loadu` を順に解決する。`loadu` を優先（macOS のパスは UTF-8）。
+        loadFn = loadSymbol(["shiori_loadu", "loadu", "shiori_load", "load"], as: ShioriLoad.self)
+        requestFn = loadSymbol(["shiori_request", "request"], as: ShioriRequest.self)
+        unloadFn = loadSymbol(["shiori_unloadu", "unloadu", "shiori_unload", "unload"], as: ShioriUnload.self)
+        freeFn = loadSymbol(["shiori_free", "free"], as: ShioriFree.self)
         self.moduleURL = url
 
         guard requestFn != nil else {

--- a/OurinTests/ExternalServerTests.swift
+++ b/OurinTests/ExternalServerTests.swift
@@ -4,7 +4,19 @@ import Testing
 
 /// 外部 SSTP サーバ経路（生テキスト → SSTPParser → SSTPDispatcher）のテスト。
 /// P2-10 の一本化により SstpRouter / SstpMessage は廃止された。
+///
+/// `ShioriStatusStore` / `SstpSessionStore` / `GhostRegistry` / `BridgeToSHIORI` の共有シングルトンを
+/// 変更するため、並列ワーカー実行下でのレースを避けるべく `.serialized` とし、各テスト前に状態を初期化する。
+@Suite(.serialized)
 struct ExternalServerTests {
+    init() {
+        BridgeToSHIORI.reset()
+        GhostRegistry.shared.clear()
+        SstpSessionStore.shared.reset()
+        ShioriStatusStore.shared.reset(to: "online")
+        unsetenv("OURIN_SSTP_LOCAL_ONLY")
+    }
+
     private func makeServer(securityLocalOnly: Bool = true) -> OurinExternalServer {
         let server = OurinExternalServer()
         server.updateConfig(.init(

--- a/OurinTests/PropertySystemTests.swift
+++ b/OurinTests/PropertySystemTests.swift
@@ -142,6 +142,39 @@ struct PropertySystemTests {
         #expect(provider.get(key: "shelllist(Winter).menu") == "hidden")
     }
 
+    @Test("Ghost generic property names (PROPERTY/1.0M §4.12)")
+    func testGhostGenericPropertyNames() {
+        let ghosts = [
+            Ghost(name: "GhostA", sakuraname: "A", path: "/a"),
+            Ghost(name: "GhostB", sakuraname: "B", path: "/b",
+                  thumbnail: "thumb.png", updateResult: "none", updateTime: "20260615",
+                  shioriVars: ["mood": "happy"])
+        ]
+        let list = GhostPropertyProvider(mode: .ghostlist, ghosts: ghosts, activeIndices: [0])
+
+        // index 汎用名（リスト内順位）
+        #expect(list.get(key: "index(1).index") == "1")
+        #expect(list.get(key: "(GhostB).index") == "1")
+        // thumbnail / update_result / update_time
+        #expect(list.get(key: "(GhostB).thumbnail") == "thumb.png")
+        #expect(list.get(key: "(GhostB).update_result") == "none")
+        #expect(list.get(key: "(GhostB).update_time") == "20260615")
+        // 未設定は nil
+        #expect(list.get(key: "(GhostA).thumbnail") == nil)
+        // shiori.<変数名>
+        #expect(list.get(key: "(GhostB).shiori.mood") == "happy")
+        #expect(list.get(key: "(GhostB).shiori.unknown") == nil)
+
+        // currentghost の *.bind.menu は SET/GET 可
+        let current = GhostPropertyProvider(mode: .currentghost, ghosts: ghosts, activeIndices: [1])
+        #expect(current.get(key: "sakura.bind.menu") == nil)
+        #expect(current.set(key: "sakura.bind.menu", value: "hidden"))
+        #expect(current.get(key: "sakura.bind.menu") == "hidden")
+        #expect(current.set(key: "char2.bind.menu", value: "auto"))
+        #expect(current.get(key: "char2.bind.menu") == "auto")
+        #expect(current.writableProperties().contains("sakura.bind.menu"))
+    }
+
     @Test("PropertyManager - Integration")
     func testPropertyManagerIntegration() {
         let manager = PropertyManager()
@@ -297,7 +330,8 @@ struct PropertySystemTests {
             activeIndices: [0],
             mouseCursor: ["text": "ibeam"],
             balloonMouseCursor: ["arrow": "default"],
-            serikoCursor: [0: ["Head": "cursor/head.cur"]],
+            // PROPERTY/1.0M: カーソルは mouseup/mousedown/mousehover/mousewheellist の4分岐
+            serikoCursor: [0: ["mousedownlist": ["Head": "cursor/head.cur"]]],
             serikoTooltips: [0: ["Head": "なでる"]],
             serikoSurfaceListAll: "0,1,2",
             serikoSurfaceListDefined: "0,2"
@@ -305,8 +339,10 @@ struct PropertySystemTests {
 
         #expect(provider.get(key: "mousecursor.text") == "ibeam")
         #expect(provider.get(key: "balloon.mousecursor.arrow") == "default")
-        #expect(provider.get(key: "seriko.cursor.scope(0).mouselist(Head).path") == "cursor/head.cur")
-        #expect(provider.get(key: "seriko.cursor.scope(0).mouselist.count") == "1")
+        #expect(provider.get(key: "seriko.cursor.scope(0).mousedownlist(Head).path") == "cursor/head.cur")
+        #expect(provider.get(key: "seriko.cursor.scope(0).mousedownlist.count") == "1")
+        // 種別が異なれば独立（mouseuplist は未定義なので 0 件）
+        #expect(provider.get(key: "seriko.cursor.scope(0).mouseuplist.count") == "0")
         #expect(provider.get(key: "seriko.surfacelist.all") == "0,1,2")
         #expect(provider.get(key: "seriko.tooltip.scope(0).textlist(Head).text") == "なでる")
         #expect(provider.get(key: "seriko.tooltip.scope(0).textlist.count") == "1")
@@ -316,8 +352,8 @@ struct PropertySystemTests {
 
         #expect(provider.set(key: "seriko.tooltip.scope(0).textlist(Hand).text", value: "つつく"))
         #expect(provider.get(key: "seriko.tooltip.scope(0).textlist(Hand).text") == "つつく")
-        #expect(provider.set(key: "seriko.cursor.scope(0).mouselist(Hand).path", value: "cursor/hand.cur"))
-        #expect(provider.get(key: "seriko.cursor.scope(0).mouselist(Hand).path") == "cursor/hand.cur")
+        #expect(provider.set(key: "seriko.cursor.scope(0).mousehoverlist(Hand).path", value: "cursor/hand.cur"))
+        #expect(provider.get(key: "seriko.cursor.scope(0).mousehoverlist(Hand).path") == "cursor/hand.cur")
     }
 
     @Test("CurrentGhost status property")

--- a/TODO/todo.md
+++ b/TODO/todo.md
@@ -1,3 +1,9 @@
+> ⚠️ **DEPRECATED (2026-06-15)**: この文書は 2025-10-21 時点のもので内容が古く、
+> `\![embed]` / `\![timerraise]` / `\![change,*]` / `\_l[x,y]` / `\f[...]` などを「未実装」と
+> 誤記している（いずれも `GhostManager.swift` に実装済み）。
+> さくらスクリプトの対応状況は **`docs/SAKURASCRIPT_COMMANDS_SUPPORTED_en-us.md` / `docs/SUPPORTED_SAKURA_SCRIPT.md` を正本**とすること。
+> 本ファイルは履歴用に残置。
+
 # SakuraScript Implementation Status
 
 **Source**: https://ssp.shillest.net/ukadoc/manual/list_sakura_script.html

--- a/docs/CODE_SPEC_DIFF_2026-06.md
+++ b/docs/CODE_SPEC_DIFF_2026-06.md
@@ -1,4 +1,9 @@
-# コードと仕様書の差異レポート (2026-06-14)
+# コードと仕様書の差異レポート (2026-06-14、追記 2026-06-15)
+
+> 2026-06-15 追記: §1 の #5(HTTPポート)・#6(XPC命名)・#7(SERIKOカーソル) を解決（詳細は §5）。
+> §2 の NAR 記載を実態（delete.txt/refresh/更新記述子取得は実装済み、更新の実適用のみ未配線）に訂正。
+> さらに §2 の プロパティ汎用名(P1)・dylib `loadu`(P2)・Plugin XPC分離(P3)・SHIORI SecurityLevel差し込み(P4) を実装（🔧）。
+
 
 `docs/` の各仕様書（ja-jp優先）と `Ourin/`・`yaya_core/` の実装を、
 SHIORI / SSTP / さくらスクリプト・SERIKO / プロパティ / FMO他 / Plugin の6領域で突き合わせた結果。
@@ -23,22 +28,23 @@ SHIORI / SSTP / さくらスクリプト・SERIKO / プロパティ / FMO他 / P
 | 2 | P1 | **メモリプロパティのキー名相違**。実装 `system.memory.physical/.available` ⇔ 仕様 `.phyt/.phya` | `PropertyManager.swift:251-252` / `PROPERTY_1.0M_SPEC_ja-jp.md:86-88` | 🔧 phyt/phya を正式キーに追加（英語別名も互換維持） |
 | 3 | P1 | **Plugin `OnOtherGhostTalk` の Ref5 仕様ずれ**。Ref5は「0x01区切りの単一Reference」だが実装は複数Referenceに展開 | `PluginEventDispatcher.swift:142-146` / `PLUGIN_EVENT_2.0M_SPEC_FULL_ja-jp.md:88-94` | 🔧 `ListDelimiter.join` で結合 |
 | 4 | P1 | **Plugin version応答が破棄**。仕様は応答Valueと任意`Charset:`を以降の通信に適用。実装は `let _ = plugin.send(req)` でログのみ | `PluginEventDispatcher.swift:64-72` / `PLUGIN_EVENT_2.0M_SPEC_ja-jp.md §4.1` | 🔧 応答をparseし交渉Charsetをプラグイン毎に保持・送信に反映 |
-| 5 | P1 | **HTTP SSTP のポートが 9810**（仕様はTCPと同じ9801） | `SstpHttpServer.swift:29`(9810) / `SstpTcpServer.swift:29`(9801) / `SSTP_1.xM_SPEC_ja-jp.md:71` | 📝 未対応（理由は §5） |
-| 6 | P1 | **XPCプロトコル二重定義・メソッド名不一致**。`OurinSSTPXPC.executeSSTP` と `OurinExternalSstpXPC.deliverSSTP`。仕様は `executeSSTP(_:withReply:)` 単一 | `Ourin/SSTP/DirectSSTPXPC.swift:3` / `Ourin/ExternalServer/XpcDirectServer.swift:5` / `SSTP_1.xM_SPEC_ja-jp.md:50,188-190` | 📝 未対応（理由は §5） |
-| 7 | P0/P1 | **SERIKOカーソルキーの構造相違**。実装は単一 `cursor.scope(ID).mouselist`、仕様は `mouseup/mousedown/mousehover/mousewheellist` の4分岐 | `GhostPropertyProvider.swift:502-533` / `PROPERTY_1.0M_SPEC_ja-jp.md:109` | 📝 未対応（要構造再設計） |
+| 5 | P1 | **HTTP SSTP のポートが 9810**（仕様はTCPと同じ9801） | `SstpHttpServer.swift` / `SstpTcpServer.swift` / `SSTP_1.xM_SPEC_ja-jp.md:71` | 🔧 **修正済 (2026-06-15)**。`UnifiedSstpListener` を新設し 9801 単一ポートで HTTP/生SSTP を先頭行判定により多重化。HTTP 専用 9810 リスナーは廃止 |
+| 6 | P1 | **XPCプロトコル二重定義・メソッド名不一致**。`OurinSSTPXPC.executeSSTP` と `OurinExternalSstpXPC.deliverSSTP`。仕様は `executeSSTP(_:withReply:)` 単一 | `Ourin/SSTP/DirectSSTPXPC.swift` / `Ourin/ExternalServer/XpcDirectServer.swift` | 🔧 **修正済 (2026-06-15)**。`OurinExternalSstpXPC` を廃止し `XpcDirectServer` を共通 `OurinSSTPXPC.executeSSTP(_:withReply:)` に統一 |
+| 7 | P0/P1 | **SERIKOカーソルキーの構造相違**。実装は単一 `cursor.scope(ID).mouselist`、仕様は `mouseup/mousedown/mousehover/mousewheellist` の4分岐 | `GhostPropertyProvider.swift` / `PROPERTY_1.0M_SPEC_ja-jp.md:109` | 🔧 **修正済 (2026-06-15)**。`serikoCursor` を `[scope:[種別:[name:path]]]` に再設計し4種リストの GET/SET に対応 |
 
 ---
 
 ## 2. 未実装・部分実装（機能拡張として計画）
 
-- 📝 **NAR更新機能(updates2.dau/updates.txt)・delete.txt 未実装**。設計のみ。`LocalNarInstaller.swift` / `NAR_INSTALL_1.0M:162-164`
-- 📝 **汎用dylib直接ロード・`loadu`エントリ未対応**。`HeadlineModule.swift:26-30`・`HeadlineRegistry.swift:26-28` は `load` のみ解決。USLはYAYA専用。
-- 📝 **Plugin XPC/プロセス分離 未実装**（`DispatchQueue`直列のみ）。`SPEC_PLUGIN_2.0M_ja-jp.md:134` でも「未実装」と記載。
-- 📝 **プロパティ汎用名 未実装**: `thumbnail / update_result / update_time / shiori.<var> / index / sakura.bind.menu`。`GhostPropertyProvider.swift:344-379`
-- 📝 **SHIORI Resource のベースウェア側キャッシュ/SET書込が無い**（毎回 `ResourceBridge.query()`）。`ResourceManager.swift`
-- 📝 **バルーン高機能描画が薄い**疑い。`Balloon/`（多形式画像/Retina/装飾が `BALLOON_1.0M_SPEC` 要求に対し簡潔）。
-- 📝 **Plugin `OnChoiceSelect(Ex)/OnAnchorSelect(Ex)/\q`** は `onArbitraryEvent()` があるが呼び出し元なし。`PluginEventDispatcher.swift:149`
-- 📝 **SHIORI 内部イベントの SecurityLevel が常に "local" 固定**（C ABI経路は SecurityLevel/Origin 差し込み機構なし）。`EventBridge.swift:397,418,440` / `ShioriLoader.swift:410-432`
+- 🔧 **NAR更新の実適用 → 対応済み (2026-06-15)**。`NarInstaller.downloadAndApply(entries:homeURLString:targetRoot:)` を新設し、`checkGhostUpdate` が更新記述子の列挙後に各ファイルをダウンロードして適用する（`.nar`/`.zip` は `install(fromNar:)`、それ以外は homeurl 基準の相対パスでゴーストルートへ保存、パストラバーサル防止）。OnUpdate.OnDownloadBegin/Complete・OnUpdateComplete を実適用結果で発火。`delete.txt`/`refresh`/`refreshundeletemask`/同梱`balloon.directory` は既存実装。
+- 🔧 **汎用dylib直接ロード・`loadu`エントリ → 対応済み (2026-06-15)**。SAORI/SHIORI(DylibBackend)/Headline/Plugin の各ローダで `loadu`(UTF-8パス版)を `load` より優先解決。SHIORI DylibBackend は無印 `load/request/unload/free`（Windows由来）も解決する汎用化。
+- 🔧 **Plugin XPC/プロセス分離 → 対応済み (2026-06-15)**。`PluginXpcBackend.swift`(`OurinPluginXPC`/`PluginXpcClient`)を新設。`OURIN_PLUGIN_ISOLATION_MODE=xpc` または `OURIN_PLUGIN_XPC_SERVICE` 指定時に `PluginEventDispatcher` が別プロセスワーカーへ送信（既定はインプロセス）。SHIORI XpcBackend と同設計。
+- 🔧 **プロパティ汎用名 → 対応済み (2026-06-15)**: `thumbnail / update_result / update_time / shiori.<var> / index` を Ghost で解決、`(sakura|kero|char*).bind.menu` を currentghost runtime 状態として GET/SET 対応。`index` は Balloon/Headline/Plugin list でも対応。
+- 🔧 **SHIORI Resource キャッシュ/SET → 対応済み (2026-06-15)**。`ResourceBridge` は既に5秒TTLキャッシュを保持。新たに SET 上書き層（`set(key:value:)`/`clearOverride(_:)`）を追加し、上書き値を SHIORI 問い合わせより優先（空文字=定義削除）。NSLock でスレッド安全化。
+- 🔧 **バルーン高機能描画 → 一部対応 (2026-06-15)**。汎用 `ImageLoader.load` に PNA（別アルファファイル）合成を追加（`CIBlendWithMask`）。`BalloonView` の縁取りを単一ブラーから8方向オフセット影による実アウトラインに改善。残: Retina(@2x) アセット選択。
+- 🔧 **Plugin `OnChoiceSelect(Ex)/OnAnchorSelect(Ex)` → 配線済み (2026-06-15)**。`GhostManager.forwardEventToPlugins` を新設し、選択肢確定（`showChoiceDialog`）とアンカークリック（`onBalloonClicked`）から `PluginEventDispatcher.onArbitraryEvent` へ横流し。残: `\q`(キュー済み選択肢) のプラグイン配線。
+- 🔧 **SHIORI 内部イベントの SecurityLevel 差し込み → 対応済み (2026-06-15)**。`EventBridge` に `ShioriSecurityContext`(level/origin)を導入し `notify`/`notifyCustom`/`sendNotify`/`sendNotifyCustom`/`sendGet` へ伝搬（既定 local）。非YAYA(`BridgeToSHIORI.handle`)経路にもヘッダを渡すよう修正（従来は SecurityLevel が欠落していた）。
+- 🔧 **大量Character表示 → 対応済み (2026-06-15)**。`GhostManager.ensureCharacterWindow(for:)` で scope ウィンドウを遅延生成。`setupWindows` は scope 0/1 のみ先行生成し、`\p[N]`(任意 N)はスコープ切替・サーフェス更新時に生成。残: 複数ゴースト同時実行（AppDelegate は単一 GhostManager 保持。アーキテクチャ変更が必要）。
 
 ---
 
@@ -64,18 +70,33 @@ SHIORI / SSTP / さくらスクリプト・SERIKO / プロパティ / FMO他 / P
 
 ---
 
-## 5. 本コミットで「修正しなかった」項目と理由
+## 5. #5/#6/#7 の対応記録（2026-06-15 解決）
 
-- **#5 HTTPポート(9810→9801)**: TCPサーバ(9801)とHTTPサーバ(9810)は `OurinExternalServer.swift:87,95` で**同時に別リスナーとしてバインド**される。HTTPを9801に変えると起動時にポート競合で破綻する。SSPは単一ポートを多重化(プロトコル判定)するが、Ourinはリスナー分離設計。正しい対応は「9801での多重化」または「設定可能ポート＋仕様文書の追従」であり、設計判断を要するため本コミットでは変更せず。
-- **#6 XPCプロトコル名**: `DirectSSTP`(同一機内ダイレクト)と`External`(外部配送)は**用途の異なる2サービス**。安易な改名は対の接続コードを破壊する。命名統一は両サービスのクライアント整合を要するため保留。
-- **#7 SERIKOカーソル構造**: 単一 `mouselist` → 4分岐への変更はプロパティ生成側の構造再設計が必要。互換影響が広く別タスクとして計画。
+当初コミットでは設計判断を要するとして保留した3件を、2026-06-15 に以下の通り解決した。
+
+- **#5 HTTPポート(9810→9801)**: 旧設計は TCP(9801)/HTTP(9810) を別リスナーとして同時バインドしていた。
+  SSP 同様の単一ポート多重化へ移行。`UnifiedSstpListener` を新設し 9801 で待ち受け、接続の先頭リクエスト行に
+  ` HTTP/` を含むかで HTTP / 生 SSTP を判別し、それぞれ `SstpHttpServer.adopt` / `SstpTcpServer.adopt`
+  （先読みバッファ引き継ぎ）に委譲する。HTTP 専用 9810 は廃止。
+- **#6 XPCプロトコル名**: `OurinExternalSstpXPC.deliverSSTP` を廃止し、`XpcDirectServer` を DirectSSTP と
+  共通の `OurinSSTPXPC.executeSSTP(_:withReply:)` へ統一。direct/external の2リスナーは用途別に維持しつつ、
+  プロトコル定義とメソッド名のみ一本化（exportedInterface も `OurinSSTPXPC` に統一）。
+- **#7 SERIKOカーソル構造**: `serikoCursor` の格納を `[scope:[name:path]]` から
+  `[scope:[種別:[name:path]]]` に再設計し、`mouseuplist/mousedownlist/mousehoverlist/mousewheellist`
+  4種の `.count` / `(hit).path|name` / `.index(ID2).path|name` を GET/SET 両対応にした。
 
 ---
 
 ## 6. 推奨対応（優先度順）
 
-1. 🔧（本コミット）CPUバグ・メモリキー・Plugin Ref5/version。
-2. ポート/XPC命名の設計判断（§5）— 外部連携互換に直結。
-3. SERIKOカーソルキー・プロパティ汎用名の仕様準拠 — 既存ゴースト資産互換。
-4. ドキュメント同期: `TODO/todo.md` 廃止、各SPECの「未実装」記載と更新日の更新、ja-jp翻訳スタブ解消。
-5. NAR更新/削除、dylib汎用ロード/`loadu`、Plugin XPC分離は機能拡張として別途計画。
+1. ✅（PR #92）CPUバグ・メモリキー・Plugin Ref5/version。
+2. ✅（2026-06-15）ポート多重化(#5)・XPC命名統一(#6)・SERIKOカーソル4分岐(#7)。
+3. ✅（2026-06-15）プロパティ汎用名(P1)・dylib `loadu`(P2)・Plugin XPC分離(P3)・SHIORI SecurityLevel差し込み(P4)。
+3b. ✅（2026-06-15 第2弾）NAR更新の実適用(R1)・Resource SET層(R2)・バルーンPNA/縁取り(R3)・Plugin選択/アンカー配線(R4)・大量Character遅延生成(R5)。
+3c. ✅（2026-06-15 第3弾）複数ゴースト同時実行 基盤(M1)・サーフェス/バルーン @2x Retina(M2)・Plugin `\q` 配線(M3)・ja-jp 翻訳スタブ解消(M4)・ExternalServerTests 並列分離(M5)。
+   - **M1**: `AppDelegate.additionalGhosts` / `launchAdditionalGhost(at:|named:)` / `terminateAdditionalGhost` を新設し複数 GhostManager を同時保持。FMO は全ゴースト集約。`\+`(bootOtherGhost) は in-process で追加起動。EventBridge は既に複数セッション対応。残: SSTP 応答ヘッダ副作用（Surface/Balloon）は依然プライマリ宛。
+   - **M2**: `RetinaImageLoader`(新規)で `name@2x.png`/`@3x` を高解像度 representation として取り込み。surface/balloon/arrow/marker ローダに適用。
+   - **M3**: `showChoiceDialog()` を再生完了時に発火するよう配線（従来は定義のみで未呼び出し）。`\q`/`\__q` が機能し、選択時に R4 経由でプラグインへ横流し。
+   - **M4**: SHIORI_RESOURCE_3.0M / SAKURASCRIPT_COMMANDS_SUPPORTED / PropertySystem / GhostConfigurationImplementation / RightClickMenuMockup / SHIORI_EVENTS_FULL_1.0M_PATCHED の ja-jp を整備。残: `YAYA_CORE_*`（内部アーキテクチャ文書、低優先）。
+   - **M5**: `ExternalServerTests` に `@Suite(.serialized)` と per-test シングルトン reset を付与（`SSTPDispatcherTests` と同方式）。
+4. 📝 残（要アーキテクチャ判断）: 複数ゴーストの SSTP 応答ヘッダ個別ルーティング・右クリックメニューのゴースト選択、`YAYA_CORE_*` 内部文書の翻訳。

--- a/docs/GhostConfigurationImplementation_ja-jp.md
+++ b/docs/GhostConfigurationImplementation_ja-jp.md
@@ -1,32 +1,264 @@
-# ゴースト設定システム実装
+> 本書は英語版原文 `GhostConfigurationImplementation_en-us.md` の日本語版です。
 
-**ステータス:** 翻訳待ち  
-**原本:** [GhostConfigurationImplementation_en-us.md](./GhostConfigurationImplementation_en-us.md)  
-**言語:** 日本語
+# ゴースト設定システムの実装
 
----
+## 概要
 
-## 翻訳ノート
+`descript.txt` ファイルからゴースト設定を読み込み、適用するための包括的なシステムを実装しました。これにより、伺かの仕様に従って、ゴーストは起動時および読み込み時に環境変数やプロパティを設定できます。
 
-このドキュメントは英語原本の日本語翻訳用プレースホルダーです。
+## 実装の概要
 
-英語版が正式な実装ドキュメントを含んでいます。この日本語版は以下を維持しながら翻訳すべきです：
+### 1. GhostConfiguration 構造体 (`Ourin/Ghost/GhostConfiguration.swift`)
 
-- 技術的正確性
-- 他の日本語ドキュメントとの用語の一貫性
-- 元の構造とフォーマット
-- すべてのコード例は変更なし
-- コメントと説明部分の適切な翻訳
+すべての `descript.txt` の値を保持する包括的な構造体を作成しました。
 
----
+**基本情報:**
+- `charset`, `type`, `name`
+- `sakura.name`, `kero.name`, `char*.name`
+- `id`, `title`
 
-## 内容
+**作者情報:**
+- `craftman`, `craftmanw`, `craftmanurl`
+- `homeurl`
 
-*(英語原本から翻訳予定)*
+**SHIORI 設定:**
+- `shiori` (DLL ファイル名)
+- `shiori.version`, `shiori.cache`, `shiori.encoding`, `shiori.forceencoding`
+- `shiori.escape_unknown`
 
----
+**サーフェス設定:**
+- `sakura.seriko.defaultsurface`, `kero.seriko.defaultsurface`
+- `char*.seriko.defaultsurface`
+- `balloon.defaultsurface`
 
-**翻訳ステータス:** ⏳ 待機中  
-**翻訳者:** 未定  
-**レビュー:** 未定  
-**最終更新日:** 2025-10-23
+**位置設定:**
+- `seriko.alignmenttodesktop` (top/bottom/free)
+- スコープ固有のアライメント: `sakura.seriko.alignmenttodesktop`, `kero.seriko.alignmenttodesktop`, `char*.seriko.alignmenttodesktop`
+- 基準位置: `sakura.defaultx/y`, `kero.defaultx/y`, `char*.defaultx/y`
+- 表示位置: `sakura.defaultleft/top`, `kero.defaultleft/top`, `char*.defaultleft/top`
+
+**SSTP 設定:**
+- `sstp.allowunspecifiedsend`, `sstp.allowcommunicate`, `sstp.alwaystranslate`
+
+**バルーン設定:**
+- `balloon`, `default.balloon.path`
+- `recommended.balloon`, `recommended.balloon.path`
+- `balloon.dontmove`, `balloon.syncscale`
+
+**UI 設定:**
+- `icon`, `icon.minimize`
+- `mousecursor`, `mousecursor.text`, `mousecursor.wait`, `mousecursor.hand`, `mousecursor.grip`, `mousecursor.arrow`
+- `menu.font.name`, `menu.font.height`
+
+**動作設定:**
+- `name.allowoverride`
+- `don't need onmousemove`, `don't need bind`, `don't need seriko talk`
+
+**AI グラフ設定:**
+- `shiori.logo.file`, `shiori.logo.x`, `shiori.logo.y`, `shiori.logo.align`
+
+**インストール:**
+- `install.accept`, `readme`, `readme.charset`
+
+### 2. ゴースト統合 (`Ourin/Property/GhostPropertyProvider.swift`)
+
+設定を含めるように `Ghost` 構造体を拡張しました。
+- `configuration: GhostConfiguration?` プロパティを追加
+- `init(from config: GhostConfiguration, path: String, username: String?)` イニシャライザを追加
+
+### 3. GhostManager 統合 (`Ourin/Ghost/GhostManager.swift`)
+
+**設定の読み込み:**
+- `ghostConfig: GhostConfiguration?` プロパティを追加
+- `start()` 中に `descript.txt` から設定を読み込み
+- デバッグ用に設定の詳細をログ出力
+
+**設定の適用:**
+- `applyGhostConfiguration(_:ghostRoot:)` メソッドを追加
+- homeurl を ResourceManager に適用
+- デフォルトのサーフェス位置 (sakura/kero/char*.defaultx/y) を適用
+- アライメント設定に基づいて表示位置を適用
+- 位置を適用する際に `seriko.alignmenttodesktop` を尊重
+- 永続化のために位置を ResourceManager に保存
+
+### 4. 包括的なテストスイート (`OurinTests/GhostConfigurationTests.swift`)
+
+以下をカバーする広範なテストを作成しました。
+- 基本パース (必須/任意フィールド)
+- サーフェス設定
+- 位置設定 (アライメントを含む)
+- キャラクター固有の位置 (char2, char3 など)
+- SSTP 設定
+- バルーン設定
+- UI 設定
+- 動作設定
+- SHIORI 設定
+- インストール設定
+- AI グラフ設定
+- Emily4 の実環境テストケース
+- Ghost 構造体の統合
+
+## 使い方
+
+### 自動読み込み
+
+設定はゴーストの起動時に自動的に読み込まれます。
+
+```swift
+let ghostRoot = ghostURL.appendingPathComponent("ghost/master", isDirectory: true)
+if let config = GhostConfiguration.load(from: ghostRoot) {
+    self.ghostConfig = config
+    applyGhostConfiguration(config, ghostRoot: ghostRoot)
+}
+```
+
+### 手動読み込み
+
+```swift
+// Load from a ghost directory
+let config = GhostConfiguration.load(from: ghostRootURL)
+
+// Parse from a dictionary
+let dict = ["name": "MyGhost", "sakura.name": "Sakura"]
+let config = GhostConfiguration.parse(from: dict)
+
+// Create programmatically
+let config = GhostConfiguration(
+    name: "TestGhost",
+    sakuraName: "Sakura",
+    keroName: "Kero"
+)
+```
+
+### 設定からの Ghost の作成
+
+```swift
+let ghost = Ghost(from: config, path: "/path/to/ghost")
+```
+
+## 設定の優先順位
+
+1. **位置設定:**
+   - `seriko.alignmenttodesktop` がグローバルなデフォルト (top/bottom/free) を設定
+   - `sakura.seriko.alignmenttodesktop` が sakura について上書き
+   - `kero.seriko.alignmenttodesktop` が kero について上書き
+   - `char*.seriko.alignmenttodesktop` が追加キャラクターについて上書き
+   - 表示位置 (`defaultleft/top`) はアライメントが `free` の場合のみ適用
+
+2. **実行時の値と descript.txt:**
+   - 設定値は起動時に読み込まれる
+   - ユーザーが変更した設定については ResourceManager の実行時の値が優先される
+   - 設定は妥当なデフォルト値を提供する
+
+## 対応エンコーディング
+
+- UTF-8 (推奨)
+- Shift_JIS/CP932 (互換性のためのフォールバック)
+
+## descript.txt の例
+
+```
+charset,Shift_JIS
+type,ghost
+name,Emily/Phase4.5
+sakura.name,Emily
+kero.name,Teddy
+balloon,emily4
+id,Emily/Phase4.5
+char2.seriko.defaultsurface,200
+name.allowoverride,0
+craftmanurl,http://ssp.shillest.net/
+craftman,[SSPBT/GL03B]Emily Development Team
+sstp.allowunspecifiedsend,1
+icon,icon.ico
+shiori,yaya.dll
+shiori.version,SHIORI/3.0
+```
+
+## 今後の拡張
+
+仕様で確認された追加候補。
+
+1. **MAKOTO サポート:**
+   - `makoto` DLL の指定
+
+2. **高度な位置制御:**
+   - シェル固有の位置の上書き
+   - 実行時の位置の永続化
+
+3. **カーソル管理:**
+   - カスタムカーソルファイルの読み込みと適用
+   - スコープ固有のカーソル設定
+
+4. **ツールチップ設定:**
+   - `currentghost.seriko.tooltip.*` プロパティ
+
+5. **履歴の追跡:**
+   - 最近使用したゴースト/バルーン/シェル
+   - 使用統計
+
+## 参考資料
+
+- UKADOC descript.txt 仕様: https://ssp.shillest.net/ukadoc/manual/descript_ghost.html
+- SSP プロパティシステム仕様
+- Ourin プロパティシステムのドキュメント: `docs/PropertySystem.md`
+
+## 変更されたファイル
+
+- **新規:** `Ourin/Ghost/GhostConfiguration.swift`
+- **新規:** `OurinTests/GhostConfigurationTests.swift`
+- **変更:** `Ourin/Property/GhostPropertyProvider.swift`
+- **変更:** `Ourin/Ghost/GhostManager.swift`
+- **修正:** `OurinTests/NarInstallTests.swift` (不足していた Foundation import を追加)
+- **修正:** `OurinTests/ShioriLoaderTests.swift` (非推奨の `#fail` を `Issue.record` に置き換え)
+
+## ビルド状況
+
+✅ ビルド成功
+✅ すべてのコードがエラーなくコンパイル
+✅ 包括的なテストスイートを作成 (すべての設定項目をカバーする 18 個のテスト)
+
+## 技術的詳細
+
+### パース戦略
+
+本実装は 2 段階のパースアプローチを採用しています。
+
+1. **ファイル読み込み:** エンコーディング検出に既存の `DescriptorLoader` パターンを使用 (まず UTF-8、次に Shift_JIS のフォールバック)
+
+2. **値のパース:** `GhostConfiguration.parse(from:)` が辞書を処理する。
+   - 必須フィールドを検証 (name は存在しなければならない)
+   - 任意フィールドには妥当なデフォルト値
+   - 安全な型変換 (Int パース、enum マッチング)
+   - `char*` エントリは正規表現パターンマッチングでパース
+
+### キャラクターパターンのパース
+
+追加キャラクター (char2, char3 など) は正規表現を用いてパースされます。
+
+```swift
+let charPattern = "^char(\\d+)\\.(.+)$"
+// Matches: char2.name, char3.defaultx, etc.
+```
+
+### エラー処理
+
+- 必須フィールドが欠けている場合は `nil` を返す
+- 無効な値を適切に処理 (デフォルトにフォールバック)
+- 不正な形式の設定については警告をログ出力
+- 重要でないフィールドには Swift のオプショナルを使用
+
+### パフォーマンス
+
+- パースはゴースト起動時に一度だけ実行される
+- 設定はメモリにキャッシュされる
+- 実行時の操作にパフォーマンスへの影響はない
+
+## 既存システムとの統合
+
+- **PropertyManager:** プロパティクエリに設定値を使用できる
+- **ResourceManager:** 設定から初期値を受け取り、実行時の変更を保存する
+- **GhostPropertyProvider:** プロパティシステムを通じて設定を公開できる
+- **SERIKO Engine:** 設定からサーフェスのデフォルト値を使用する
+- **SSTP Server:** SSTP の許可設定を尊重する
+- **Balloon System:** 設定からバルーンの設定を使用する

--- a/docs/PLUGIN_EVENT_2.0M_SPEC_ja-jp.md
+++ b/docs/PLUGIN_EVENT_2.0M_SPEC_ja-jp.md
@@ -206,23 +206,26 @@ Value: OK
 
 ### 実装済みのイベント
 
-- [ ] `version`: 未実装
-- [ ] `installedplugin` [NOTIFY]: 未実装
-- [ ] `installedghostname` [NOTIFY]: 未実装
-- [ ] `installedballoonname` [NOTIFY]: 未実装
-- [ ] `ghostpathlist` [NOTIFY]: 未実装
-- [ ] `balloonpathlist` [NOTIFY]: 未実装
-- [ ] `headlinepathlist` [NOTIFY]: 未実装
-- [ ] `pluginpathlist` [NOTIFY]: 未実装
-- [ ] `OnSecondChange`: 未実装
-- [ ] `OnOtherGhostTalk`: 未実装
-- [ ] `OnGhostBoot`: 未実装
-- [ ] `OnGhostExit` [NOTIFY]: 未実装
-- [ ] `OnGhostInfoUpdate` [NOTIFY]: 未実装
-- [ ] `OnMenuExec`: 未実装
-- [ ] `OnInstallComplete`: 未実装
-- [ ] `OnChoiceSelect(Ex)`: 未実装
-- [ ] `OnAnchorSelect(Ex)`: 未実装
+> 更新 2026-06-15: 旧版は全イベント「未実装」と誤記していた。実態は `PluginEventDispatcher.swift` に
+> 主要イベントが実装済み。以下を実コードに合わせて訂正。
+
+- [x] `version`: 実装済み（応答 Value/Charset を交渉しプラグイン毎に保持）
+- [x] `installedplugin` [NOTIFY]: 実装済み（`ListDelimiter.join` で結合）
+- [x] `installedghostname` [NOTIFY]: 実装済み（`sendFrame` 経由の NOTIFY）
+- [x] `installedballoonname` [NOTIFY]: 実装済み（`sendFrame` 経由の NOTIFY）
+- [x] `ghostpathlist` [NOTIFY]: 実装済み（`sendFrame` 経由の NOTIFY）
+- [x] `balloonpathlist` [NOTIFY]: 実装済み（`sendFrame` 経由の NOTIFY）
+- [x] `headlinepathlist` [NOTIFY]: 実装済み（`sendFrame` 経由の NOTIFY）
+- [x] `pluginpathlist` [NOTIFY]: 実装済み（`sendFrame` 経由の NOTIFY）
+- [x] `OnSecondChange`: 実装済み（`onSecondChange` + タイマー）
+- [x] `OnOtherGhostTalk`: 実装済み（Ref5 は 0x01 区切り単一 Reference）
+- [x] `OnGhostBoot`: 実装済み（`onGhostBoot`）
+- [x] `OnGhostExit` [NOTIFY]: 実装済み（`onGhostExit`）
+- [x] `OnGhostInfoUpdate` [NOTIFY]: 実装済み（`onGhostInfoUpdate`）
+- [x] `OnMenuExec`: 実装済み（`onMenuExec`）
+- [x] `OnInstallComplete`: 実装済み（`onInstallComplete`）
+- [~] `OnChoiceSelect(Ex)`: 送信経路は汎用 `onArbitraryEvent` で対応可能だが**呼び出し元が未配線**（要接続）
+- [~] `OnAnchorSelect(Ex)`: 同上（`onArbitraryEvent` 経由・呼び出し元未配線）
 - [x] `![raiseplugin]`/`![notifyplugin]`: 実装済み（`OurinPluginEventBridge.swift` 経由で transport 処理）
 
 ### 実装ファイル

--- a/docs/PropertySystem_ja-jp.md
+++ b/docs/PropertySystem_ja-jp.md
@@ -1,32 +1,230 @@
-# Property System Implementation
+> 本書は en-us 版原文（PropertySystem_en-us.md）の日本語訳です。
 
-**ステータス:** 翻訳待ち  
-**原本:** [PropertySystem_en-us.md](./PropertySystem_en-us.md)  
-**言語:** 日本語
+# プロパティシステムの実装
 
----
+## 概要
 
-## 翻訳ノート
+プロパティシステムは、伺かのプロパティシステム仕様に従い、ゴーストスクリプトが実行時にベースウェアのパラメータを読み書きできるようにする仕組みです。これにより、ゴーストはシステム情報、ベースウェアの詳細、実行時データへ標準化された方法でアクセスできます。
 
-このドキュメントは英語原本の日本語翻訳用プレースホルダーです。
+## アーキテクチャ
 
-英語版が正式な仕様を含んでいます。この日本語版は以下を維持しながら翻訳すべきです：
+### 主要コンポーネント
 
-- 技術的正確性
-- 他の日本語ドキュメントとの用語の一貫性
-- 元の構造とフォーマット
-- すべてのコード例は変更なし
-- コメントと説明部分の適切な翻訳
+1. **PropertyProvider プロトコル** (`PropertyProvider.swift`)
+   - すべてのプロパティプロバイダの基底プロトコル
+   - プロパティの読み取り用に `get(key:)` をサポート
+   - プロパティの書き込み用に `set(key:value:)` をサポート（任意）
 
----
+2. **PropertyManager** (`PropertyManager.swift`)
+   - すべてのプロパティプロバイダを統括する中央マネージャ
+   - プレフィックスに基づいて、プロパティ要求を適切なプロバイダへ振り分け
+   - `%property[...]` 環境変数の展開をサポート
 
-## 内容
+### プロパティプロバイダ
 
-*(英語原本から翻訳予定)*
+#### SystemPropertyProvider
+`system.*` プロパティを提供します:
+- 日付/時刻: `system.year`, `system.month`, `system.day`, `system.hour`, `system.minute`, `system.second`, `system.millisecond`, `system.dayofweek`
+- カーソル: `system.cursor.pos`
+- OS 情報: `system.os.type`, `system.os.name`, `system.os.version`, `system.os.build`
+- CPU 情報: `system.cpu.num`, `system.cpu.vendor`, `system.cpu.name`, `system.cpu.clock`, `system.cpu.features`, `system.cpu.load`
+- メモリ情報: `system.memory.phyt`, `system.memory.phya`, `system.memory.load`
 
----
+#### BasewarePropertyProvider
+`baseware.*` プロパティを提供します:
+- `baseware.name` - "Ourin" を返す
+- `baseware.version` - アプリケーションのバージョンを返す
 
-**翻訳ステータス:** ⏳ 待機中  
-**翻訳者:** 未定  
-**レビュー:** 未定  
-**最終更新日:** 2025-10-23
+#### GhostPropertyProvider
+`ghostlist.*`, `activeghostlist.*`, `currentghost.*` に関するゴースト関連プロパティを提供します:
+
+**共通プロパティ:**
+- `name`, `sakuraname`, `keroname`
+- `craftmanw`, `craftmanurl`
+- `path`, `icon`, `homeurl`
+- `username`
+
+**ghostlist:**
+- `ghostlist.count` - インストール済みゴーストの数
+- `ghostlist.index(n).{property}` - インデックスでゴーストにアクセス
+- `ghostlist({name|sakuraname|path}).{property}` - 識別子でゴーストにアクセス
+
+**currentghost:**
+- 上記の基本プロパティ
+- `currentghost.status` - ゴーストのステータス
+- `currentghost.shelllist.count` - シェルの数
+- `currentghost.shelllist.current.{property}` - 現在のシェルのプロパティ
+- `currentghost.shelllist({name|path}).{property}` - 識別子で指定したシェル
+- `currentghost.shelllist.index(n).{property}` - インデックスで指定したシェル
+- `currentghost.scope.count` - スコープの数
+- `currentghost.scope(n).surface.num` - スコープのサーフェス番号
+- `currentghost.scope(n).{x|y|rect|name}` - スコープの位置と情報
+
+**シェルプロパティ:**
+- `name`, `path`, `menu` (hidden/empty)
+
+**スコーププロパティ:**
+- `surface.num`, `surface.x`, `surface.y`
+- `x`, `y`, `rect`
+- `name`, `seriko.defaultsurface`
+
+#### BalloonPropertyProvider
+バルーン関連のプロパティを提供します:
+
+**balloonlist:**
+- `balloonlist.count`
+- `balloonlist.index(n).{name|path|craftmanw|craftmanurl}`
+- `balloonlist({name|path}).{property}`
+
+**currentghost.balloon:**
+- `balloon.scope(n).count` - バルーン画像の数
+- `balloon.scope(n).num` - バルーン ID
+- `balloon.scope(n).validwidth` - テキスト描画幅
+- `balloon.scope(n).validheight` - テキスト描画高さ
+- `balloon.scope(n).lines` - 最大行数
+- `balloon.scope(n).basepos.{x|y}` - テキスト開始位置
+- `balloon.scope(n).char_width` - 文字幅
+
+#### HeadlinePropertyProvider
+`headlinelist.*` プロパティを提供します:
+- `headlinelist.count`
+- `headlinelist.index(n).{name|path|craftmanw|craftmanurl}`
+- `headlinelist({name|path}).{property}`
+
+#### PluginPropertyProvider
+`pluginlist.*` プロパティを提供します:
+- `pluginlist.count`
+- `pluginlist.index(n).{name|path|id|craftmanw|craftmanurl}`
+- `pluginlist({name|path|id}).{property}`
+
+## 使い方
+
+### 環境変数の展開
+
+SakuraScript のテキスト内で `%property[key]` を使用してプロパティ値を埋め込みます:
+
+```
+%property[baseware.name] ver,%property[baseware.version]
+```
+
+これは次のように展開されます:
+```
+Ourin ver,1.0
+```
+
+### SakuraScript タグ
+
+#### プロパティの取得
+
+プロパティ値を取得し、その値を伴って SHIORI イベントを発火させます:
+
+```
+\![get,property,EventName,PropertyKey]
+```
+
+例:
+```
+\![get,property,OnGetSakuraName,ghostlist(Emily/Phase4.5).keroname]
+```
+
+これは `Reference0` に値 "Teddy" を含めた `OnGetSakuraName` イベントを発火させます。
+
+#### プロパティの設定
+
+書き込み可能なプロパティ値を設定します:
+
+```
+\![set,property,PropertyKey,Value]
+```
+
+例:
+```
+\![set,property,currentghost.shelllist(ULTIMATE FORM).menu,hidden]
+```
+
+これはシェル変更メニューから "ULTIMATE FORM" シェルを非表示にします。
+
+### プログラムからのアクセス
+
+```swift
+let manager = PropertyManager()
+
+// Get property
+if let year = manager.get("system.year") {
+    print("Current year: \(year)")
+}
+
+// Set property
+manager.set("currentghost.shelllist(Default).menu", value: "hidden")
+
+// Expand text with properties
+let text = "Welcome to %property[baseware.name]!"
+let expanded = manager.expand(text: text)
+```
+
+## 書き込み可能なプロパティ
+
+現在、以下のプロパティが書き込み操作をサポートしています:
+
+1. `currentghost.shelllist({name}).menu` - "hidden" を設定するとメニューからシェルを非表示にする
+
+## 統合ポイント
+
+### GhostManager
+`GhostManager` クラスはプロパティ関連の SakuraScript コマンドを処理します:
+- `\![get,property,...]` （408 行目）
+- `\![set,property,...]` （421 行目）
+
+### SakuraScriptEngine
+`SakuraScriptEngine` は `PropertyManager` と統合されています:
+- プロパティアクセス用に `propertyManager` プロパティを提供
+- `%property[...]` の展開を `EnvironmentExpander` に委譲
+
+### EnvironmentExpander
+テキスト内の `%property[key]` 展開を処理します:
+- `EnvironmentExpander.swift` の 109-111 行目
+- `PropertyManager.get()` に委譲
+
+## テスト
+
+包括的なテストが `PropertySystemTests.swift` に用意されています:
+- システムプロパティ（日付/時刻、OS 情報）
+- ベースウェアプロパティ
+- ゴーストプロパティ（ghostlist, currentghost）
+- プロパティの展開
+- バルーン、ヘッドライン、プラグインのプロパティ
+- SET 機能
+
+テストの実行:
+```bash
+xcodebuild test -project Ourin.xcodeproj -scheme Ourin
+```
+
+## 今後の拡張
+
+仕様への完全準拠に向けた追加候補:
+
+1. **履歴プロパティ** (`history.*`)
+   - `history.ghost.*`, `history.balloon.*` など
+   - 最近使用した項目のトラッキング
+
+2. **使用率** (`rateofuselist.*`)
+   - ゴーストの使用統計
+   - 起動時間のトラッキング
+   - 使用率の計算
+
+3. **追加の書き込み可能プロパティ**
+   - マウスカーソルのカスタマイズ (`currentghost.mousecursor.*`)
+   - ツールチップのカスタマイズ (`currentghost.seriko.tooltip.*`)
+   - サーフェスリストのプロパティ (`currentghost.seriko.surfacelist.*`)
+
+4. **動的データ連携**
+   - 実際の実行時ゴースト/シェル/バルーンデータへの接続
+   - リアルタイムなスコープ位置のトラッキング
+   - ライブなバルーンメトリクス
+
+## 参考資料
+
+- UKADOC プロパティシステム仕様: https://usada.sakura.vg/contents/specification.html
+- SSP のプロパティ実装
+- CROW のプロパティテストケース

--- a/docs/RightClickMenuMockup_ja-jp.md
+++ b/docs/RightClickMenuMockup_ja-jp.md
@@ -1,32 +1,17 @@
-# SSP Right-Click Menu Mockup
+> 本ドキュメントは英語版原文 `RightClickMenuMockup_en-us.md` の日本語版です。
 
-**ステータス:** 翻訳待ち  
-**原本:** [RightClickMenuMockup_en-us.md](./RightClickMenuMockup_en-us.md)  
-**言語:** 日本語
+# SSP 右クリックメニューのモックアップ
 
----
+以下のコンテキストメニューは、[ukadoc](https://ssp.shillest.net/ukadoc/ssphelp/howto-rclick.html) に記載されているメニューと、SHIORI プロトコル仕様（[spec_shiori3](https://ssp.shillest.net/ukadoc/manual/spec_shiori3.html)、[specification2](http://usada.sakura.vg/contents/specification2.html#shioriprotocol)）を参考にしています。
 
-## 翻訳ノート
+```
+ゴースト情報
+ゴースト切替 > ゴースト1, ゴースト2
+シェル切替 > シェル1, シェル2
+バルーン切替 > バルーン1
+----------------
+設定
+終了
+```
 
-このドキュメントは英語原本の日本語翻訳用プレースホルダーです。
-
-英語版が正式な仕様を含んでいます。この日本語版は以下を維持しながら翻訳すべきです：
-
-- 技術的正確性
-- 他の日本語ドキュメントとの用語の一貫性
-- 元の構造とフォーマット
-- すべてのコード例は変更なし
-- コメントと説明部分の適切な翻訳
-
----
-
-## 内容
-
-*(英語原本から翻訳予定)*
-
----
-
-**翻訳ステータス:** ⏳ 待機中  
-**翻訳者:** 未定  
-**レビュー:** 未定  
-**最終更新日:** 2025-10-23
+このモックアップは `RightClickMenu.swift` に実装されており、`ContentView.swift` から使用されます。

--- a/docs/SAKURASCRIPT_COMMANDS_SUPPORTED_ja-jp.md
+++ b/docs/SAKURASCRIPT_COMMANDS_SUPPORTED_ja-jp.md
@@ -1,32 +1,616 @@
-# Sakura Script Commands - Supported in Ourin
+# Sakura Script Commands - Ourin 対応状況
 
-**ステータス:** 翻訳待ち  
-**原本:** [SAKURASCRIPT_COMMANDS_SUPPORTED_en-us.md](./SAKURASCRIPT_COMMANDS_SUPPORTED_en-us.md)  
-**言語:** 日本語
+これは en-us 版オリジナル（`SAKURASCRIPT_COMMANDS_SUPPORTED_en-us.md`）の日本語版です。
 
----
+このドキュメントは、現在 Ourin の `SakuraScriptEngine` がサポートしているすべてのさくらスクリプトコマンドを一覧化したものです。
 
-## 翻訳ノート
+## 2026-03 ukadoc ギャップ監査（優先度順）
 
-このドキュメントは英語原本の日本語翻訳用プレースホルダーです。
+ukadoc（`/manual/list_sakura_script.html`）と `GhostManager` の現行ランタイムハンドラを比較した結果、主な残存ギャップは以下のとおりです。
 
-英語版が正式な仕様を含んでいます。この日本語版は以下を維持しながら翻訳すべきです：
+1. **イベント連携のギャップ（高）**  
+   - `\![embed,event,...]` インラインイベント埋め込み  
+   - `\![timerraise,ms,repeat,event,...]` 遅延／繰り返しイベント発火  
+   - ステータス: **本アップデートで実装済み**
 
-- 技術的正確性
-- 他の日本語ドキュメントとの用語の一貫性
-- 元の構造とフォーマット
-- すべてのコード例は変更なし
-- コメントと説明部分の適切な翻訳
+2. **ランタイム切り替えのギャップ（高）**  
+    - `\![change,ghost,name]` 完全なゴースト切り替えセマンティクス  
+    - `\![change,shell,name]` シェル切り替えと再描画  
+    - `\![change,balloon,name]` バルーン設定切り替え  
+   - ステータス: **本アップデートで拡張**（`--option=raise-event`、`OnGhostChanging/Changed`、`OnShellChanging/Changed`、`OnBalloonChange`）
+   - 関連: `\![call,ghost,name]` ランタイムパスを `OnGhostCalling/OnGhostCalled` とともに追加
 
----
+3. **ダイアログ系のギャップ（高）**  
+   - `\![open,inputbox|dateinput|sliderinput|dialog|teachbox,...]`  
+   - ステータス: **本アップデートで拡張**（`passwordinput|timeinput|ipinput` を追加、`--timeout`、`--text` などのオプション形式引数、ダイアログサブタイプ `open/save/folder/color` に対応）
 
-## 内容
+8. **入力以外の open 系（高）**  
+   - `\![open,browser|mailer|editor|explorer|file|readme|terms|help,...]` および `\![open,communicatebox]`  
+   - `\![close,inputbox|communicatebox|dialog|teachbox,...]`  
+   - ステータス: **本アップデートで実装済み**（ランタイムルーティングを追加し、既存のダイアログイベントパスを再利用）
+   - 拡張: `\![open,ghostexplorer|shellexplorer|balloonexplorer|headlinesensorexplorer|pluginexplorer|rateofusegraph|calendar|messenger|surfacetest|aigraph]`
 
-*(英語原本から翻訳予定)*
+9. **プラグインイベント系（高）**  
+   - `\![raiseplugin|notifyplugin,plugin,event,...]`  
+   - `\![timerraiseplugin|timernotifyplugin,ms,repeat,plugin,event,...]`  
+   - ステータス: **本アップデートで実装済み**（id／name／filename に加えて `random`／`lastinstalled` によるプラグインターゲット解決、タイマーの上書き／キャンセルセマンティクス）
 
----
+4. **サウンド拡張系（中）**  
+   - `\![sound,play|load|loop|wait|pause|resume|stop|option,...]`  
+   - ステータス: **本アップデートで拡張**（`load/wait/pause/resume/option` ランタイムパスを追加）
 
-**翻訳ステータス:** ⏳ 待機中  
-**翻訳者:** 未定  
-**レビュー:** 未定  
-**最終更新日:** 2025-10-23
+5. **セマンティクス不一致コマンド（中）**  
+   - `\6`、`\7`、`\-` の挙動が一部 ukadoc の期待と異なる  
+   - ステータス: **本アップデートで対応**（`\7` は SNTP フローを開始、`\6` は SNTP 調整アクションを適用、`\-` はゴーストを終了）
+
+6. **ゴースト間イベントルーティング（高）**  
+   - `\![raiseother,...]`、`\![notifyother,...]`  
+   - `\![timerraiseother,...]`、`\![timernotifyother,...]`  
+   - ステータス: **本アップデートで実装済み**（バイト1区切り文字や `__SYSTEM_ALL_GHOST__` を含むターゲット解析、キー単位のタイマースケジューリング／キャンセル）
+
+7. **notify タイマーセマンティクス（高）**  
+   - `\![notify,...]`、`\![timernotify,...]` のレスポンス処理とタイマー挙動  
+   - ステータス: **本アップデートで実装済み**（`notify` はレスポンススクリプトを破棄するようになり、`timerraise/timernotify` は 0=繰り返し、>=1=一回限り に従い、`ms=0` によるイベント単位のキャンセル／上書きをサポート）
+
+## スコープコマンド
+
+### キャラクター／スコープ選択
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\0` or `\h` | Sakura（キャラクター0）に切り替え | `\0Hello from Sakura` |
+| `\1` or `\u` | Unyuu（キャラクター1）に切り替え | `\1Hello from Unyuu` |
+| `\pN` | キャラクターN（0-9）に切り替え | `\p2Hello from third character` |
+| `\p[N]` | キャラクターN（任意のID）に切り替え | `\p[15]Hello from character 15` |
+
+## サーフェスコマンド
+
+### サーフェス表示
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\sN` | サーフェスをID N（0-9）に変更 | `\s1Switch to surface 1` |
+| `\s[N]` | サーフェスをID N（任意のID）に変更 | `\s[100]Switch to surface 100` |
+| `\s[-1]` | サーフェスを非表示 | `\s[-1]Character becomes invisible` |
+
+## アニメーションコマンド
+
+### 基本アニメーション
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\i[ID]` | アニメーションIDを再生 | `\i[10]Play animation 10` |
+| `\i[ID,wait]` | アニメーションを再生し完了まで待機 | `\i[100,wait]This text appears after animation` |
+
+### アニメーション制御（`\!` コマンド経由）
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![anim,clear,ID]` | アニメーションIDを停止 | `\![anim,clear,100]` |
+| `\![anim,pause,ID]` | アニメーションIDを一時停止 | `\![anim,pause,200]` |
+| `\![anim,resume,ID]` | 一時停止中のアニメーションIDを再開 | `\![anim,resume,200]` |
+| `\![anim,offset,ID,x,y]` | アニメーション位置をオフセット | `\![anim,offset,300,40,50]` |
+| `\![anim,stop]` | すべてのアニメーションを停止 | `\![anim,stop]` |
+
+### アニメーションレイヤー制御
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![anim,add,overlay,ID]` | 現在のサーフェスにサーフェスIDをオーバーレイ | `\![anim,add,overlay,10]` |
+| `\![anim,add,overlayfast,ID]` | overlayfast モードでオーバーレイ | `\![anim,add,overlayfast,10]` |
+| `\![anim,add,base,ID]` | ベースサーフェスをIDに変更 | `\![anim,add,base,5]` |
+| `\![anim,add,move,x,y]` | サーフェスを座標に移動 | `\![anim,add,move,100,200]` |
+
+## バルーンコマンド
+
+### バルーンID切り替え
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\bN` | バルーンをID N（0-9のみ）に変更 | `\b2Switch to balloon 2` |
+| `\b[ID]` | バルーンをID（任意のID、負数で非表示）に変更 | `\b[2]Large balloon` |
+| `\b[-1]` | バルーンを非表示 | `\b[-1]Hidden` |
+
+**注意:**
+- メインキャラクターのバルーンには偶数ID（0, 2, 4, 6, 8）のみ使用可能
+- 奇数IDはパートナー／右側バルーン用に予約されています
+- SSP 2.6.34+ はフォールバック構文をサポート: `\b[ID1,--fallback=ID2,--fallback=ID3]`
+
+### バルーン画像
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\_b[file,x,y]` | XY座標に画像を表示（左上を透過） | `\_b[image\test.png,50,100]` |
+| `\_b[file,x,y,opaque]` | 透過なしで画像を表示 | `\_b[test.png,0,15,opaque]` |
+| `\_b[file,inline]` | テキストとインラインで画像を表示 | `Text\_b[icon.png,inline]more` |
+| `\_b[file,inline,opaque]` | 透過なしでインライン画像を表示 | `\_b[icon.png,inline,opaque]` |
+
+**オプション**（`\_b[file,x,y,options...]` または `\_b[file,inline,options...]` 用）:
+- `--option=opaque` - 透過なし
+- `--option=use_self_alpha` - PNGのアルファチャンネルを使用
+- `--clipping=left top right bottom` - 画像領域を切り抜き
+- `--option=fixed` - テキストとともにスクロールしない
+- `--option=background` - テキストの背後に表示（デフォルト）
+- `--option=foreground` - テキストの前面に表示
+
+**例:**
+```
+\_b[test.png,10,20,--option=use_self_alpha,--clipping=100 30 150 90,--option=foreground]
+```
+
+### バルーン制御
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![set,autoscroll,disable]` | オートスクロールを無効化 | `\![set,autoscroll,disable]` |
+| `\![set,autoscroll,enable]` | オートスクロールを有効化 | `\![set,autoscroll,enable]` |
+| `\![set,balloonoffset,x,y]` | バルーンオフセットを設定 | `\![set,balloonoffset,100,-50]` |
+| `\![set,balloonoffset,@x,@y]` | バルーンの相対オフセットを設定 | `\![set,balloonoffset,@100,@-50]` |
+| `\![set,balloonalign,DIR]` | バルーンの配置を設定（left/center/top/right/bottom/none） | `\![set,balloonalign,top]` |
+| `\![set,balloonmarker,text]` | SSTP受信マーカーを設定 | `\![set,balloonmarker,SSTP]` |
+| `\![set,balloonnum,file,cur,max]` | ファイル転送インジケータを設定 | `\![set,balloonnum,test.zip,1,5]` |
+| `\![set,balloontimeout,ms]` | バルーンタイムアウトを設定（0 または -1 = タイムアウトなし） | `\![set,balloontimeout,3000]` |
+| `\![set,balloonwait,rate]` | テキスト速度の倍率を設定 | `\![set,balloonwait,1.5]` |
+| `\![set,serikotalk,true/false]` | SERIKOの口パクアニメーションを有効化／無効化 | `\![set,serikotalk,false]` |
+| `\![enter,onlinemode]` | オンラインマーカー表示を強制 | `\![enter,onlinemode]` |
+| `\![leave,onlinemode]` | オンラインマーカーを非表示 | `\![leave,onlinemode]` |
+| `\![enter,nouserbreakmode]` | ユーザーによるスクリプト中断を無効化 | `\![enter,nouserbreakmode]` |
+| `\![leave,nouserbreakmode]` | ユーザーによるスクリプト中断を有効化 | `\![leave,nouserbreakmode]` |
+| `\![lock,balloonrepaint]` | アンロックまたはスクリプト終了までバルーンの再描画をロック | `\![lock,balloonrepaint]` |
+| `\![lock,balloonrepaint,manual]` | 明示的なアンロックまでバルーンの再描画をロック | `\![lock,balloonrepaint,manual]` |
+| `\![unlock,balloonrepaint]` | バルーンの再描画をアンロック | `\![unlock,balloonrepaint]` |
+| `\![lock,balloonmove]` | バルーンのドラッグ移動を禁止 | `\![lock,balloonmove]` |
+| `\![unlock,balloonmove]` | バルーンのドラッグ移動を許可 | `\![unlock,balloonmove]` |
+
+## テキスト制御コマンド
+
+### 基本テキスト制御
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\n` | 改行 | `Line 1\nLine 2` |
+| `\n[half]` | 半分の高さの改行 | `Line 1\n[half]Line 2` |
+| `\n[percent]` | 任意の高さの改行（行高に対する%） | `Line 1\n[150]Line 2` |
+| `\e` | スクリプト終了 | `Done\e` |
+| `\C` | 追記モード（前のバルーンに追記） | `\CAppend to previous` |
+
+### テキスト配置
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\_l[x,y]` | カーソルをXY座標に配置 | `\_l[30,100]Positioned` |
+
+**座標フォーマット:**
+- 数値: 左上からのピクセル（例: `30`）
+- em: 文字の高さ（例: `5em`）
+- lh: 行の高さ（例: `2lh`）
+- %: 文字高に対する割合（例: `100%`）
+- @: 現在位置からの相対（例: `@-100`）
+- パラメータを省略すると現在値を維持（例: `\_l[,@-100]` はYのみ移動）
+
+**例:**
+```
+\_l[30,5em]       Text at X=30px, Y=5 characters
+\_l[@-1650%,100]  X=left 16.5 characters, Y=100px
+\_l[,@-100]       Same X, 100px up
+```
+
+### テキストクリア
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\c` | 現在のスコープのバルーンをクリア | `Text\cCleared` |
+| `\c[char,N]` | カーソルからN文字をクリア | `Delete\c[char,3]End` |
+| `\c[char,N,start]` | 指定位置からN文字をクリア | `Text\c[char,3,4]End` |
+| `\c[line,N]` | カーソルからN行をクリア | `Line 1\nLine 2\c[line,1]` |
+| `\c[line,N,start]` | 指定位置からN行をクリア | `\c[line,1,2]` |
+
+**注意:**
+- 文字／行のカウントは表示位置ではなくスクリプト順に従います
+- `\_b[file,inline]` 画像は1文字としてカウントされます
+- `\n`、`\n[...]`、`\_l[x,y]` で区切られた行は別々の行としてカウントされます
+- 空行（例: `\n\n`）はカウントされません
+
+### テキスト折り返し
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\_n` | 自動折り返しを無効化（次の `\_n` まで） | `\_nNo wrap\_n` |
+
+### 待機コマンド
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\w[N]` | N×50ms 待機 | `\w[10]Wait 500ms` |
+| `\__w[animation,ID]` | アニメーションIDの完了を待機 | `\__w[animation,400]` |
+
+### タグのそのまま表示（パススルー）
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\_!...\_!` | タグをそのまま表示（旧フォーマット） | `\_!\1Text\n\_!` は `\1Text\n` を表示 |
+| `\_?...\_?` | タグをそのまま表示 | `\_?\1Text\n\_?` は `\1Text\n` を表示 |
+
+**注意:**
+- 開始タグと終了タグの間のテキストはさくらスクリプトとして解釈されません
+- サンプルスクリプトの表示やデバッグに便利です
+
+### 音声合成制御
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\__v[disable]...\__v` | テキストの音声合成を無効化 | `\__v[disable]Silent\__v` |
+| `\__v[alternate,text]...\__v` | 読み上げを上書き | `\__v[alternate,ひらがな]漢字\__v` |
+
+## フォント＆テキストスタイルコマンド
+
+### テキスト揃え
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\f[align,left]` | テキストを左揃え | `\f[align,left]Left aligned` |
+| `\f[align,center]` | テキストを中央揃え | `\f[align,center]Centered` |
+| `\f[align,right]` | テキストを右揃え | `\f[align,right]Right aligned` |
+| `\f[valign,top]` | 上に垂直揃え | `\f[valign,top]Top` |
+| `\f[valign,center]` | 中央に垂直揃え | `\f[valign,center]Middle` |
+| `\f[valign,bottom]` | 下に垂直揃え | `\f[valign,bottom]Bottom` |
+
+**注意:**
+- `\f[align,...]` は次の意図的な改行（`\n`、`\_l`）まで有効
+- `\_l` タグは揃えを左にリセット
+- `\f[valign,...]` は改行でリセットされません（`align` とは異なります）
+- 揃えコマンドの後に追加されたテキストは、同じ行の前のテキストを遡及的に揃えます
+
+### フォントプロパティ
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\f[name,font]` | フォントを変更（単一の名前またはファイル） | `\f[name,Arial]Arial font` |
+| `\f[name,font1,font2,...]` | フォールバック付きでフォントを変更 | `\f[name,メイリオ,meiryo.ttf]Text` |
+| `\f[height,size]` | フォントサイズを設定（ピクセル） | `\f[height,15]Size 15` |
+| `\f[height,+N]` | 相対的にサイズを拡大 | `\f[height,+3]Bigger` |
+| `\f[height,-N]` | 相対的にサイズを縮小 | `\f[height,-3]Smaller` |
+| `\f[height,N%]` | デフォルトサイズに対する割合 | `\f[height,200%]Double size` |
+
+**フォント名に関する注意:**
+- `default` - バルーンのデフォルトフォントにリセット
+- `disable` - 無効テキスト用フォントを使用
+- `ghost/master/` またはバルーンフォルダ内のフォントファイルを指定可能
+- カンマ区切りの複数の名前 = 優先順位（SSPのみ）
+
+### テキストカラー
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\f[color,name]` | 名前付きカラー | `\f[color,red]Red text` |
+| `\f[color,r,g,b]` | RGBカラー（0-255） | `\f[color,100,150,200]Blue` |
+| `\f[color,#RRGGBB]` | 16進カラー | `\f[color,#ff6600]Orange` |
+| `\f[color,default]` | バルーンのデフォルトにリセット | `\f[color,default]Normal` |
+| `\f[shadowcolor,...]` | 影の色（同じフォーマット） | `\f[shadowcolor,#ffff00]Yellow shadow` |
+| `\f[shadowcolor,none]` | 影を無効化 | `\f[shadowcolor,none]No shadow` |
+| `\f[shadowstyle,offset]` | オフセット影（デフォルト） | `\f[shadowstyle,offset]Offset` |
+| `\f[shadowstyle,outline]` | アウトライン影 | `\f[shadowstyle,outline]Outlined` |
+| `\f[anchor.font.color,...]` | アンカーテキストの色 | `\f[anchor.font.color,50%,90%,20%]Link` |
+
+**カラーフォーマットに関する注意:**
+- 名前付きカラー: `red`、`blue`、`green`、`black`、`white` など
+- RGB: 0-255 の3つの数値、または `50%,90%,20%` のような割合
+- 16進: 標準的なWeb形式 `#RRGGBB`
+
+### テキストスタイル
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\f[bold,1]` or `\f[bold,true]` | 太字を有効化 | `\f[bold,1]Bold text` |
+| `\f[bold,0]` or `\f[bold,false]` | 太字を無効化 | `\f[bold,0]Normal` |
+| `\f[bold,default]` | バルーンのデフォルトにリセット | `\f[bold,default]Default` |
+| `\f[bold,disable]` | 無効テキストスタイルを使用 | `\f[bold,disable]Disabled` |
+| `\f[italic,1]` | 斜体を有効化 | `\f[italic,1]Italic` |
+| `\f[strike,1]` | 取り消し線を有効化 | `\f[strike,1]Strike` |
+| `\f[underline,1]` | 下線を有効化 | `\f[underline,1]Underline` |
+| `\f[outline,1]` | アウトライン（白文字）を有効化 | `\f[outline,1]Outlined` |
+
+**注意:**
+- すべてのスタイルコマンドは次に対応: `1`/`true`（有効）、`0`/`false`（無効）、`default`、`disable`
+- フォントがそのスタイルに対応している必要があります（太字／斜体のバリアントがないフォントもあります）
+
+### テキスト位置
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\f[sub,1]` | 下付き文字を有効化 | `H\f[sub,1]2\f[sub,0]O` |
+| `\f[sup,1]` | 上付き文字を有効化 | `X\f[sup,1]2\f[sup,0]` |
+
+### リセットコマンド
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\f[default]` | すべてのフォント属性をバルーンのデフォルトにリセット | `\f[default]Reset all` |
+| `\f[disable]` | すべての属性を無効テキストスタイルに設定 | `\f[disable]Disabled` |
+
+**組み合わせ例:**
+```
+\f[shadowcolor,#6699cc]\f[bold,1]\f[underline,1]\f[height,20]Styled text\f[default]Normal
+\f[align,center]\f[color,red]\f[height,24]Centered Red Title\n
+H\f[sub,1]2\f[sub,0]O + O\f[sub,1]2\f[sub,0] → H\f[sub,1]2\f[sub,0]O\f[sub,1]2\f[sub,0]
+```
+
+## キャラクター移動コマンド
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\4` | 他のキャラクターから離れる | `Moving...\4Done` |
+| `\5` | 他のキャラクターに近づく | `Moving...\5Done` |
+| `\![move,args...]` | 指定位置へ移動（下記参照） | 移動セクション参照 |
+| `\![moveasync,args...]` | 非同期で移動 | 移動セクション参照 |
+| `\![moveasync,cancel]` | 非同期移動をキャンセル | `\![moveasync,cancel]` |
+
+### move コマンドのパラメータ
+
+フォーマット: `\![move,--X=x,--Y=y,--time=ms,--base=ref,--base-offset=pos,--move-offset=pos,--option=opt]`
+
+**パラメータ:**
+- `--X=value`: X座標（負数可）
+- `--Y=value`: Y座標（負数可）
+- `--time=ms`: 移動時間（ミリ秒）
+- `--base=ref`: 基準点（screen, primaryscreen, ID, ghost/ID, me, global）
+- `--base-offset=pos`: 基準点のアンカー（left.top, right.bottom, center.center など）
+- `--move-offset=pos`: 揃えるキャラクターのアンカー
+- `--option=opt`: オプション（ignore-sticky-window）
+
+**例:**
+```
+\![move,--X=80,--Y=-400,--time=2500,--base=screen,--base-offset=left.bottom,--move-offset=left.top]
+```
+
+## 着せ替え／バインドコマンド
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![bind,category,part,1]` | カテゴリのパーツを装着 | `\![bind,head,ribbon,1]` |
+| `\![bind,category,part,0]` | カテゴリからパーツを外す | `\![bind,head,ribbon,0]` |
+| `\![bind,category,,0]` | カテゴリ内のすべてのパーツを外す | `\![bind,arm,,0]` |
+| `\![bind,category,part]` | パーツの装着／解除をトグル | `\![bind,head,ribbon]` |
+
+## 描画制御
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![lock,repaint]` | アンロックまたはスクリプト終了まで再描画を停止 | `\![lock,repaint]` |
+| `\![lock,repaint,manual]` | 明示的なアンロックまで再描画を停止 | `\![lock,repaint,manual]` |
+| `\![unlock,repaint]` | 再描画を再開 | `\![unlock,repaint]` |
+
+## 位置＆配置
+
+### デスクトップ配置
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![set,alignmentondesktop,bottom]` | デスクトップ下端にスナップ | `\![set,alignmentondesktop,bottom]` |
+| `\![set,alignmentondesktop,top]` | デスクトップ上端にスナップ | `\![set,alignmentondesktop,top]` |
+| `\![set,alignmenttodesktop,DIR]` | 配置方向を設定 | 下表参照 |
+
+**配置方向:**
+- `top` - 上端にスナップ
+- `bottom` - 下端にスナップ
+- `left` - 左端にスナップ
+- `right` - 右端にスナップ
+- `free` - スナップなし
+- `default` - デフォルトにリセット
+
+### 位置ロック
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![set,position,x,y,scopeID]` | キャラクターを指定位置にロック | `\![set,position,100,200,0]` |
+| `\![reset,position]` | 位置のロックを解除 | `\![reset,position]` |
+
+## ビジュアルエフェクト
+
+### スケーリング
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![set,scaling,ratio]` | 等倍スケーリング（%） | `\![set,scaling,50]` |
+| `\![set,scaling,x,y]` | 非等倍スケーリング（%） | `\![set,scaling,50,100]` |
+| `\![set,scaling,x,y,time]` | アニメーションスケーリング（time はミリ秒） | `\![set,scaling,50,100,2500]` |
+
+**注意:**
+- 100 = ユーザーが設定したスケール（100%）
+- 負の値は軸を反転（-100 = 反転）
+- ゴーストが終了するまで持続します
+
+### 透明度
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![set,alpha,value]` | 透明度を設定（0-100） | `\![set,alpha,50]` |
+
+**注意:**
+- 0 = 完全に透明（不可視）
+- 100 = 完全に不透明
+- ゴーストが終了するまで持続します
+
+### エフェクト＆フィルタ
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![effect,plugin,speed,params]` | プラグインエフェクトを適用 | `\![effect,plugin1,2.0,param]` |
+| `\![effect2,surfaceID,plugin,speed,params]` | 追加サーフェスにエフェクトを適用 | `\![effect2,10,plugin1,2.0,param]` |
+| `\![filter,plugin,time,params]` | 継続的なフィルタを適用 | `\![filter,plugin2,1000,param]` |
+| `\![filter]` | フィルタをクリア | `\![filter]` |
+
+## ウィンドウ管理
+
+### Zオーダー
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![set,zorder,ID1,ID2,...]` | ウィンドウの重なり順を設定 | `\![set,zorder,1,0]` |
+| `\![reset,zorder]` | デフォルトのZオーダーにリセット | `\![reset,zorder]` |
+
+**注意:**
+- 左から右の順にリストされたID = 前面から背面
+- 例: `\![set,zorder,1,0]` はキャラクター1を常にキャラクター0の前面にします
+
+### スティッキーウィンドウ
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![set,sticky-window,ID1,ID2,...]` | ウィンドウを連動して移動するようリンク | `\![set,sticky-window,1,0]` |
+| `\![reset,sticky-window]` | ウィンドウのリンクを解除 | `\![reset,sticky-window]` |
+
+**注意:**
+- リンクされたウィンドウはドラッグ時に連動して移動します
+- `\![move]` コマンドでも機能します（--option=ignore-sticky-window を除く）
+
+### ウィンドウリセット
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `\![execute,resetwindowpos]` | すべてのウィンドウを初期位置にリセット | `\![execute,resetwindowpos]` |
+
+## 特殊コマンド
+
+### マーカー
+
+| コマンド | 説明 | 例 |
+|---------|-------------|---------|
+| `%*` or `\![*]` | マーカーを挿入 | `Text before%*Text after` |
+
+## エスケープシーケンス
+
+| シーケンス | 結果 | 例 |
+|----------|--------|---------|
+| `\\` | リテラルの `\` | `C:\\Users` → `C:\Users` |
+| `\%` | リテラルの `%` | `100\%` → `100%` |
+| `\]` | リテラルの `]`（ブラケット内） | `\![test,a\]b]` → 引数: `["test", "a]b"]` |
+| `\[` | リテラルの `[`（ブラケット内） | `\![test,a\[b]` → 引数: `["test", "a[b"]` |
+
+## 引数のクォート
+
+`[...]` ブラケット内の引数はカンマ区切りで、クォートに対応しています。
+
+| ルール | 例 | 結果 |
+|------|---------|--------|
+| 基本 | `\![raise,OnTest,100]` | `["raise", "OnTest", "100"]` |
+| クォート内のカンマ | `\![raise,OnTest,"100,2"]` | `["raise", "OnTest", "100,2"]` |
+| エスケープされたクォート | `\![call,ghost,"the ""Master"""]` | `["call", "ghost", "the \"Master\""]` |
+
+## 実装ステータス
+
+### ✅ 完全実装
+
+#### パーサーレベル（SakuraScriptEngine.swift）
+上記のすべてのコマンドは **正しくパースされます**。パーサーはさくらスクリプトのテキストを、レンダリングエンジンが処理できるトークンに変換します。
+
+#### レンダリングレベル（GhostManager.swift + CharacterViewModel/CharacterView）
+
+**ビジュアルエフェクト - 実装済み:**
+- ✅ `\![set,scaling,ratio]` - 等倍スケーリング
+- ✅ `\![set,scaling,x,y]` - 非等倍スケーリング
+- ✅ `\![set,alpha,value]` - 透明度（0-100）
+- ✅ `\![lock,repaint]` / `\![unlock,repaint]` - 描画制御
+- ✅ `\![set,alignmenttodesktop,DIR]` - デスクトップ配置の状態
+- ✅ `\![set,position,x,y,scopeID]` / `\![reset,position]` - 位置ロックの状態
+- ✅ `\![set,zorder,...]` / `\![reset,zorder]` - Zオーダーグルーピングの状態
+- ✅ `\![set,sticky-window,...]` / `\![reset,sticky-window]` - スティッキーウィンドウグルーピングの状態
+- ✅ `\![execute,resetwindowpos]` - すべてのウィンドウ位置／配置をリセット
+
+**コマンド処理:**
+- キャラクターのビジュアル状態は `CharacterViewModel` に `@Published` プロパティとして保存されます
+- ビジュアルエフェクトは `CharacterView` で SwiftUI モディファイア（`.scaleEffect()`、`.opacity()`、`.allowsHitTesting()`）を使って適用されます
+- すべての設定はゴーストが終了するまで持続します（UKADOC仕様に準拠）
+- `\![lock,repaint]` は `manual` オプションが使われていない限り、スクリプト終了時に自動的にアンロックされます
+
+### ⚠️ 部分実装
+
+**ウィンドウ管理 - 状態は保存、挙動はTODO:**
+これらのコマンドは ViewModel の状態を正しく更新しますが、実際のウィンドウ挙動にはプラットフォーム側の実装が必要です。
+- ⚠️ 配置制約（特定方向へのウィンドウ移動の防止）
+- ⚠️ 位置ロック（ウィンドウのドラッグを無効化）
+- ⚠️ Zオーダーの強制（ウィンドウを指定の重なり順に維持）
+- ⚠️ スティッキーウィンドウの同期（複数ウィンドウの連動移動）
+
+### ❌ 未実装（実行レベル）
+
+**バルーン＆テキストコマンド - パースのみ:**
+すべてのバルーンおよびテキストコマンドは完全にパースされますが、実行はまだ実装されていません。
+- ❌ `\bN` / `\b[ID]` - バルーンID切り替え（パース済み、プレースホルダーあり）
+- ❌ `\C` - 追記モード（パース済み、プレースホルダーあり）
+- ❌ `\n[half]` / `\n[percent]` - 可変改行高（パース済み、通常の改行として扱われる）
+- ❌ `\_b[...]` - バルーン画像（インラインおよび位置指定）
+- ❌ `\_l[x,y]` - テキストカーソルの配置
+- ❌ `\c` / `\c[char/line,...]` - テキストクリア
+- ❌ `\_n` - 自動折り返し無効モード
+- ❌ `\_!...\_!` / `\_?...\_?` - タグのパススルー（正しくパース済み）
+- ❌ `\__v[...]` - 音声合成制御
+- ❌ `\![set,autoscroll,...]` - オートスクロール制御
+- ❌ `\![set,balloonoffset,...]` - バルーンオフセット
+- ❌ `\![set,balloonalign,...]` - バルーン配置
+- ❌ `\![set,balloonmarker,...]` - SSTPマーカー
+- ❌ `\![set,balloonnum,...]` - ファイル転送インジケータ
+- ❌ `\![set,balloontimeout,...]` - バルーンタイムアウト
+- ❌ `\![set,balloonwait,...]` - テキスト速度
+- ❌ `\![set,serikotalk,...]` - SERIKO口パクアニメーション
+- ❌ `\![enter/leave,onlinemode]` - オンラインマーカー
+- ❌ `\![enter/leave,nouserbreakmode]` - ユーザーブレイク制御
+- ❌ `\![lock/unlock,balloonrepaint]` - バルーン再描画制御
+- ❌ `\![lock/unlock,balloonmove]` - バルーンドラッグ制御
+
+**フォント＆テキストスタイルコマンド - パースのみ:**
+すべてのフォントおよびテキストスタイルコマンドは完全にパースされますが、実行はまだ実装されていません。
+- ❌ `\f[align,...]` - テキスト揃え（left/center/right）
+- ❌ `\f[valign,...]` - テキストの垂直揃え（top/center/bottom）
+- ❌ `\f[name,...]` - フォントファミリの変更
+- ❌ `\f[height,...]` - フォントサイズ（絶対・相対・割合）
+- ❌ `\f[color,...]` - テキストカラー
+- ❌ `\f[shadowcolor,...]` - 影の色
+- ❌ `\f[shadowstyle,...]` - 影のスタイル（offset/outline）
+- ❌ `\f[anchor.font.color,...]` - アンカーテキストの色
+- ❌ `\f[bold,...]` - 太字スタイル
+- ❌ `\f[italic,...]` - 斜体スタイル
+- ❌ `\f[strike,...]` - 取り消し線
+- ❌ `\f[underline,...]` - 下線
+- ❌ `\f[outline,...]` - アウトライン（白文字）スタイル
+- ❌ `\f[sub,...]` - 下付き文字
+- ❌ `\f[sup,...]` - 上付き文字
+- ❌ `\f[default]` - すべてのフォント属性をリセット
+- ❌ `\f[disable]` - 無効テキストスタイルを設定
+
+**移動:**
+- ❌ `\4` および `\5` - 基本的なキャラクター移動（パース済み、ハンドラのプレースホルダーあり）
+- ❌ `\![move,...]` / `\![moveasync,...]` - パラメータ付きの複雑な移動
+
+**アニメーション:**
+- ❌ `\![anim,clear,ID]` / `\![anim,pause,ID]` / `\![anim,resume,ID]` / `\![anim,stop]`
+- ❌ `\![anim,offset,ID,x,y]`
+- ❌ `\![anim,add,*]` - アニメーションレイヤリング
+- ❌ `\__w[animation,ID]` - アニメーション完了の待機
+
+**着せ替え:**
+- ❌ `\![bind,category,part,value]` - 着せ替えシステム全体はまだ実装されていません
+
+**エフェクト＆フィルタ:**
+- ❌ `\![effect,...]` / `\![effect2,...]` / `\![filter,...]` - プラグインベースのエフェクト
+- ❌ `\![set,scaling,x,y,time]` - 時間経過によるアニメーションスケーリング
+
+**注意:**
+- パーサーはすべてのコマンドを正しく識別し、パラメータを抽出します
+- 将来の実装に向けて、TODOコメント付きのプレースホルダーハンドラが存在します
+- 一部の機能はプラットフォーム固有の NSWindow 操作を必要とします
+- アニメーション、バルーン、着せ替えの各システムには追加のインフラが必要です
+
+## テスト
+
+すべてのコマンドは `OurinTests/SakuraScriptEngineTests.swift` で包括的なテストカバレッジを持っています。次のコマンドでテストを実行します。
+
+```bash
+xcodebuild -project Ourin.xcodeproj -scheme Ourin -only-testing:OurinTests/SakuraScriptEngineTests test
+```
+
+## 参考資料
+
+- 完全仕様: `docs/SAKURASCRIPT_FULL_1.0M_PATCHED.md`
+- パーサー実装: `Ourin/SakuraScript/SakuraScriptEngine.swift`
+- テストスイート: `OurinTests/SakuraScriptEngineTests.swift`

--- a/docs/SERIKO_IMPLEMENTATION.md
+++ b/docs/SERIKO_IMPLEMENTATION.md
@@ -93,7 +93,9 @@ Current linkage is command-level through `GhostManager` handlers:
 
 ## Current Status / 現在のステータス
 
-**Status**: Parser Complete, Executor Exists but Not Integrated / パーサー完了、エグゼキューターは存在するが統合されていない / 2026-03-15
+**Status**: Parser Complete, Executor Integrated / パーサー完了・エグゼキューター統合済み / updated 2026-06-15
+（旧 2026-03-15 版は「統合されていない」と記載していたが、`GhostManager+Animation.swift` 経由で
+コールバック配線・タイマー駆動・`\![anim,*]` ルーティングが完了済み。下記の旧ギャップ記述は解消済み。）
 
 ### Implemented Components / 実装済みコンポーネント
 
@@ -104,19 +106,18 @@ Complete SERIKO/2.0 parser with:
 - Pattern parsing and surface definitions
 - surfaces.txt parsing
 
-#### ✅ **SerikoExecutor.swift** (Exists but Not Connected / 存在するが接続されていない)
+#### ✅ **SerikoExecutor.swift** (Connected / 接続済み)
 Fully functional animation execution engine with:
 - Animation state management
 - executeAnimation(), startLoop() methods
 - All execute methods (overlay, base, move, reduce, replace, start, stop, etc.)
 - Pause/resume/offset capabilities
 - Callback system (onMethodInvoked, onPatternExecuted, onAnimationFinished)
-- **BUT: Callbacks not wired to GhostManager**
+- ✅ Callbacks wired to GhostManager (`GhostManager+Animation.swift`)
 
-#### ⚠️ **GhostManager+Animation.swift** (Partial / 部分的)
-Integration hooks exist but:
-- SerikoExecutor callbacks not connected
-- Handler methods (handleSurfaceOverlay, etc.) may not invoke actual rendering
+#### ✅ **GhostManager+Animation.swift** (Integrated / 統合済み)
+- SerikoExecutor callbacks connected
+- Timer-driven loop (`serikoExecutor.startLoop()`) and `\![anim,*]` routing in place
 
 ### Integration Gaps / 統合のギャップ
 - ✅ **SerikoExecutor callbacks connected** - wired via GhostManager animation handlers

--- a/docs/SHIORI_3.0M_SPEC_ja-jp.md
+++ b/docs/SHIORI_3.0M_SPEC_ja-jp.md
@@ -173,7 +173,7 @@ void shiori_free(unsigned char* p){ free(p); }
 - [x] **文字コード対応**: UTF-8 既定、Shift_JIS/CP932 受理機能を実装済み
 - [x] **リクエスト/レスポンス処理**: CRLF + 空行終端の基本的なワイヤプロトコル処理を実装済み
 - [ ] **Bundle/Plugin 形式の SHIORI**: C ABI での直接ロードは未実装（現在は YAYA のみ対応）
-- [ ] **XPC 分離実行**: 未実装（現在は同一プロセス内で実行）
+- [x] **XPC 分離実行**: 実装済み（`ShioriLoader.swift` の `XpcBackend` が `OurinShioriXPC` で `Data->Data` を橋渡し。更新 2026-06-15）
 - [ ] **shiori_free メモリ管理**: C ABI 未実装のため該当なし
 
 ### 11.2 実装済みの機能
@@ -198,12 +198,10 @@ void shiori_free(unsigned char* p){ free(p); }
    - `shiori_load`, `shiori_request`, `shiori_unload`, `shiori_free` 関数の実装
    - CFBundle からの関数ポインタ解決
 
-2. **XPC サービス分離**
-   - SHIORI の別プロセス実行
-   - セキュリティサンドボックス分離
+2. ~~**XPC サービス分離**~~ → 実装済み（`XpcBackend`）。別プロセス実行・サンドボックス分離に対応。
 
 3. **SHIORI/2.x 互換**
-   - 2.x プロトコルのサポート
+   - 2.x プロトコルのサポート（バイナリ IPC 規約のため未対応。3.0 一本化）
 
 ## 12. 適合チェックリスト
 - [x] `GET/NOTIFY SHIORI/3.0`、CRLF＋空行終端で往復できる（YAYA バックエンドで実装）  

--- a/docs/SHIORI_EVENTS_FULL_1.0M_PATCHED_ja-jp.md
+++ b/docs/SHIORI_EVENTS_FULL_1.0M_PATCHED_ja-jp.md
@@ -1,32 +1,464 @@
+> 本書は en-us 版「SHIORI_EVENTS_FULL_1.0M_PATCHED_en-us.md」の日本語版です。
+
 # SHIORI Events FULL (Ourin/1.0M)
 
-**ステータス:** 翻訳待ち  
-**原本:** [SHIORI_EVENTS_FULL_1.0M_PATCHED_en-us.md](./SHIORI_EVENTS_FULL_1.0M_PATCHED_en-us.md)  
-**言語:** 日本語
+> メソッドの規則（UKADOC 準拠）:
+> - イベントが UKADOC のリスト（https://ssp.shillest.net/ukadoc/manual/list_shiori_event.html）で明示的に「[NOTIFY]」と記されていない限り、その既定メソッドは GET です。
+> - 「[NOTIFY]」と記載されているイベントのみが既定で NOTIFY です。それ以外はすべて既定で GET です。
+> - 本書も同じ慣例に従います。以下の ID について「Method」が示されていない場合は、実装固有の注記で別途指定されない限り、既定で GET と見なしてください。
+
+## Notify 専用イベント（戻り値は無視される）
+UKADOC の「Notifyイベント」に従い、以下の ID は NOTIFY で送信され、返されたスクリプトはベースウェア側で無視されなければなりません。Ourin も同じ挙動に従います。
+
+- `basewareversion`
+- `hwnd`
+- `uniqueid`
+- `capability`
+- `ownerghostname`
+- `otherghostname`
+- `installedsakuraname`
+- `installedkeroname`
+- `installedghostname`
+- `installedshellname`
+- `installedballoonname`
+- `installedheadlinename`
+- `installedplugin`
+- `configuredbiffname`
+- `ghostpathlist`
+- `balloonpathlist`
+- `headlinepathlist`
+- `pluginpathlist`
+- `calendarskinpathlist`
+- `calendarpluginpathlist`
+- `rateofusegraph`
+- `enable_log`
+- `enable_debug`
+- `OnNotifySelfInfo`
+- `OnNotifyBalloonInfo`
+- `OnNotifyShellInfo`
+- `OnNotifyDressupInfo`
+- `OnNotifyUserInfo`
+- `OnNotifyOSInfo`
+- `OnNotifyFontInfo`
+- `OnNotifyInternationalInfo`
+
+参照: https://ssp.shillest.net/ukadoc/manual/list_shiori_event.html
+
+| ID | Ourin(mac) メモ |
+|---|---|
+| `OnFirstBoot` | OS 非依存 |
+| `OnBoot` | EventHub でのライフサイクル対応付け |
+| `OnClose` | EventHub でのライフサイクル対応付け |
+| `OnCloseAll` | OS 非依存 |
+| `OnGhostChanged` | EventHub でのライフサイクル対応付け |
+| `OnGhostChanging` | EventHub でのライフサイクル対応付け |
+| `OnGhostCalled` | OS 非依存 |
+| `OnGhostCalling` | OS 非依存 |
+| `OnGhostCallComplete` | OS 非依存 |
+| `OnOtherGhostBooted` | OS 非依存 |
+| `OnOtherGhostChanged` | OS 非依存 |
+| `OnOtherGhostClosed` | OS 非依存 |
+| `OnShellChanged` | Ourin におけるシェル/バルーンの更新 |
+| `OnShellChanging` | Ourin におけるシェル/バルーンの更新 |
+| `OnDressupChanged` | 着せ替えフック（SERIKO パーツ） |
+| `OnBalloonChange` | Ourin におけるシェル/バルーンの更新 |
+| `OnWindowStateRestore` | OS 非依存 |
+| `OnWindowStateMinimize` | OS 非依存 |
+| `OnFullScreenAppMinimize` | OS 非依存 |
+| `OnFullScreenAppRestore` | OS 非依存 |
+| `OnVirtualDesktopChanged` | OS 非依存 |
+| `OnCacheSuspend` | OS 非依存 |
+| `OnCacheRestore` | OS 非依存 |
+| `OnInitialize` | OS 非依存 |
+| `OnDestroy` | OS 非依存 |
+| `OnSysResume` | OS 非依存 |
+| `OnSysSuspend` | OS 非依存 |
+| `OnBasewareUpdating` | OS 非依存 |
+| `OnBasewareUpdated` | OS 非依存 |
+| `OnTeachStart` | OS 非依存 |
+| `OnTeachInputCancel` | OS 非依存 |
+| `OnTeach` | OS 非依存 |
+| `OnCommunicate` | OS 非依存 |
+| `OnCommunicateInputCancel` | OS 非依存 |
+| `OnUserInput` | OS 非依存 |
+| `OnUserInputCancel` | OS 非依存 |
+| `OnSystemDialog` | OS 非依存 |
+| `OnSystemDialogCancel` | OS 非依存 |
+| `OnConfigurationDialogHelp` | OS 非依存 |
+| `OnGhostTermsAccept` | OS 非依存 |
+| `OnGhostTermsDecline` | OS 非依存 |
+| `OnSecondChange` | OS 非依存 |
+| `OnMinuteChange` | OS 非依存 |
+| `OnHourTimeSignal` | OS 非依存 |
+| `OnVanishSelecting` | OS 非依存 |
+| `OnVanishSelected` | OS 非依存 |
+| `OnVanishCancel` | OS 非依存 |
+| `OnVanishButtonHold` | OS 非依存 |
+| `OnVanished` | OS 非依存 |
+| `OnOtherGhostVanished` | OS 非依存 |
+| `OnChoiceSelect` | OS 非依存 |
+| `OnChoiceSelectEx` | OS 非依存 |
+| `OnChoiceEnter` | OS 非依存 |
+| `OnChoiceTimeout` | OS 非依存 |
+| `OnChoiceHover` | OS 非依存 |
+| `OnAnchorSelect` | OS 非依存 |
+| `OnAnchorSelectEx` | OS 非依存 |
+| `OnAnchorEnter` | OS 非依存 |
+| `OnAnchorHover` | OS 非依存 |
+| `OnSurfaceChange` | OS 非依存 |
+| `OnSurfaceRestore` | OS 非依存 |
+| `OnOtherSurfaceChange` | OS 非依存 |
+| `OnMouseClick` | OS 非依存 |
+| `OnMouseClickEx` | OS 非依存 |
+| `OnMouseDoubleClick` | NSEvent から対応付け（画面→論理座標） |
+| `OnMouseDoubleClickEx` | OS 非依存 |
+| `OnMouseMultipleClick` | OS 非依存 |
+| `OnMouseMultipleClickEx` | OS 非依存 |
+| `OnMouseUp` | NSEvent から対応付け（画面→論理座標） |
+| `OnMouseUpEx` | OS 非依存 |
+| `OnMouseDown` | NSEvent から対応付け（画面→論理座標） |
+| `OnMouseDownEx` | OS 非依存 |
+| `OnMouseMove` | NSEvent から対応付け（画面→論理座標） |
+| `OnMouseWheel` | OS 非依存 |
+| `OnMouseEnterAll` | OS 非依存 |
+| `OnMouseLeaveAll` | OS 非依存 |
+| `OnMouseEnter` | OS 非依存 |
+| `OnMouseLeave` | OS 非依存 |
+| `OnMouseDragStart` | OS 非依存 |
+| `OnMouseDragEnd` | OS 非依存 |
+| `OnMouseHover` | OS 非依存 |
+| `OnMouseGesture` | OS 非依存 |
+| `OnBalloonBreak` | OS 非依存 |
+| `OnBalloonClose` | OS 非依存 |
+| `OnBalloonTimeout` | OS 非依存 |
+| `OnTrayBalloonClick` | OS 非依存 |
+| `OnTrayBalloonTimeout` | OS 非依存 |
+| `OnInstallBegin` | OS 非依存 |
+| `OnInstallComplete` | OS 非依存 |
+| `OnInstallCompleteEx` | OS 非依存 |
+| `OnInstallCompleteAll` | OS 非依存 |
+| `OnInstallFailure` | OS 非依存 |
+| `OnInstallRefuse` | OS 非依存 |
+| `OnInstallReroute` | OS 非依存 |
+| `OnFileDropping` | OS 非依存 |
+| `OnFileDropped` | OS 非依存 |
+| `OnOtherObjectDropping` | OS 非依存 |
+| `OnOtherObjectDropped` | OS 非依存 |
+| `OnDirectoryDrop` | OS 非依存 |
+| `OnWallpaperChange` | OS 非依存 |
+| `OnFileDrop` | OS 非依存 |
+| `OnFileDropEx` | OS 非依存 |
+| `OnFileDrop2` | OS 非依存 |
+| `OnUpdatedataCreating` | OS 非依存 |
+| `OnUpdatedataCreated` | OS 非依存 |
+| `OnNarCreating` | OS 非依存 |
+| `OnNarCreated` | OS 非依存 |
+| `OnURLDragDropping` | OS 非依存 |
+| `OnURLDropping` | OS 非依存 |
+| `OnURLDropped` | OS 非依存 |
+| `OnURLDropFailure` | OS 非依存 |
+| `OnURLQuery` | OS 非依存 |
+| `OnXUkagakaLinkOpen` | OS 非依存 |
+| `OnUpdateProcessExec` | OS 非依存 |
+| `OnUpdateBegin` | OS 非依存 |
+| `OnUpdateReady` | OS 非依存 |
+| `OnUpdateComplete` | OS 非依存 |
+| `OnUpdateFailure` | OS 非依存 |
+| `OnUpdate` | OS 非依存 |
+| `OnDownloadBegin` | OS 非依存 |
+| `OnMD5CompareBegin` | OS 非依存 |
+| `OnMD5CompareComplete` | OS 非依存 |
+| `OnMD5CompareFailure` | OS 非依存 |
+| `OnUpdateOtherBegin` | OS 非依存 |
+| `OnUpdateOtherReady` | OS 非依存 |
+| `OnUpdateOtherComplete` | OS 非依存 |
+| `OnUpdateOtherFailure` | OS 非依存 |
+| `OnUpdateOther` | OS 非依存 |
+| `OnUpdateCheckComplete` | OS 非依存 |
+| `OnUpdateCheckFailure` | OS 非依存 |
+| `OnUpdateResult` | OS 非依存 |
+| `OnUpdateResultEx` | OS 非依存 |
+| `OnUpdateCheckResult` | OS 非依存 |
+| `OnUpdateCheckResultEx` | OS 非依存 |
+| `OnUpdateResultExplorer` | OS 非依存 |
+| `OnSNTPBegin` | OS 非依存 |
+| `OnSNTPCompareEx` | OS 非依存 |
+| `OnSNTPCompare` | OS 非依存 |
+| `OnSNTPCorrectEx` | OS 非依存 |
+| `OnSNTPCorrect` | OS 非依存 |
+| `OnSNTPFailure` | OS 非依存 |
+| `OnBIFFBegin` | OS 非依存 |
+| `OnBIFFComplete` | OS 非依存 |
+| `OnBIFF2Complete` | OS 非依存 |
+| `OnBIFFFailure` | OS 非依存 |
+| `OnHeadlinesenseBegin` | OS 非依存 |
+| `OnHeadlinesense` | OS 非依存 |
+| `OnFind` | OS 非依存 |
+| `OnHeadlinesenseComplete` | OS 非依存 |
+| `OnHeadlinesenseFailure` | OS 非依存 |
+| `OnRSSBegin` | OS 非依存 |
+| `OnRSSComplete` | OS 非依存 |
+| `OnRSSFailure` | OS 非依存 |
+| `OnSchedule5MinutesToGo` | OS 非依存 |
+| `OnScheduleRead` | OS 非依存 |
+| `OnSchedulesenseBegin` | OS 非依存 |
+| `OnSchedulesenseComplete` | OS 非依存 |
+| `OnSchedulesenseFailure` | OS 非依存 |
+| `OnSchedulepostBegin` | OS 非依存 |
+| `OnSchedulepostComplete` | OS 非依存 |
+| `OnSSTPBreak` | SSTP は既定で localhost のみ |
+| `OnSSTPBlacklisting` | SSTP は既定で localhost のみ |
+| `OnExecuteHTTPComplete` | OS 非依存 |
+| `OnExecuteHTTPFailure` | OS 非依存 |
+| `OnExecuteHTTPProgress` | OS 非依存 |
+| `OnExecuteHTTPSSLInfo` | OS 非依存 |
+| `OnExecuteRSSComplete` | OS 非依存 |
+| `OnExecuteRSSFailure` | OS 非依存 |
+| `OnExecuteRSS_SSLInfo` | OS 非依存 |
+| `OnPingComplete` | OS 非依存 |
+| `OnPingProgress` | OS 非依存 |
+| `OnNSLookupComplete` | OS 非依存 |
+| `OnNSLookupFailure` | OS 非依存 |
+| `OnRaisePluginFailure` | OS 非依存 |
+| `OnNotifyPluginFailure` | OS 非依存 |
+| `OnRaiseOtherFailure` | OS 非依存 |
+| `OnNotifyOtherFailure` | OS 非依存 |
+| `OnOverlap` | OS 非依存 |
+| `OnOtherOverlap` | OS 非依存 |
+| `OnOffscreen` | OS 非依存 |
+| `OnOtherOffscreen` | OS 非依存 |
+| `OnNetworkHeavy` | OS 非依存 |
+| `OnNetworkStatusChange` | OS 非依存 |
+| `OnScreenSaverStart` | OS 非依存 |
+| `OnScreenSaverEnd` | OS 非依存 |
+| `OnSessionLock` | OS 非依存 |
+| `OnSessionUnlock` | OS 非依存 |
+| `OnSessionDisconnect` | OS 非依存 |
+| `OnSessionReconnect` | OS 非依存 |
+| `OnCPULoadHigh` | OS 非依存 |
+| `OnCPULoadLow` | OS 非依存 |
+| `OnMemoryLoadHigh` | OS 非依存 |
+| `OnMemoryLoadLow` | OS 非依存 |
+| `OnDisplayChange` | OS 非依存 |
+| `OnDisplayHandover` | OS 非依存 |
+| `OnDisplayChangeEx` | OS 非依存 |
+| `OnDisplayPowerStatus` | OS 非依存 |
+| `OnBatteryNotify` | OS 非依存 |
+| `OnBatteryLow` | OS 非依存 |
+| `OnBatteryCritical` | OS 非依存 |
+| `OnBatteryChargingStart` | OS 非依存 |
+| `OnBatteryChargingStop` | OS 非依存 |
+| `OnDeviceArrival` | OS 非依存 |
+| `OnDeviceRemove` | OS 非依存 |
+| `OnTabletMode` | OS 非依存 |
+| `OnDarkTheme` | OS 非依存 |
+| `OnOSUpdateInfo` | OS 非依存 |
+| `OnRecycleBinEmpty` | OS 非依存 |
+| `OnRecycleBinEmptyFromOther` | OS 非依存 |
+| `OnRecycleBinStatusUpdate` | OS 非依存 |
+| `OnSelectModeBegin` | OS 非依存 |
+| `OnSelectModeCancel` | OS 非依存 |
+| `OnSelectModeComplete` | OS 非依存 |
+| `OnSelectModeMouseDown` | OS 非依存 |
+| `OnSelectModeMouseUp` | OS 非依存 |
+| `OnSpeechSynthesisStatus` | OS 非依存 |
+| `OnVoiceRecognitionStatus` | OS 非依存 |
+| `OnVoiceRecognitionWord` | OS 非依存 |
+| `OnKeyPress` | キーイベントから対応付け（IME 対応） |
+| `OnRecommendsiteChoice` | OS 非依存 |
+| `OnTranslate` | OS 非依存 |
+| `OnAITalk` | OS 非依存 |
+| `OnOtherGhostTalk` | OS 非依存 |
+| `OnEmbryoExist` | OS 非依存 |
+| `OnNekodorifExist` | OS 非依存 |
+| `OnSoundStop` | OS 非依存 |
+| `OnSoundError` | OS 非依存 |
+| `OnTextDrop` | OS 非依存 |
+| `OnShellScaling` | OS 非依存 |
+| `OnBalloonScaling` | OS 非依存 |
+| `OnLanguageChange` | OS 非依存 |
+| `OnResetWindowPos` | OS 非依存 |
+| `OnNotifySelfInfo` | OS 非依存 |
+| `OnNotifyBalloonInfo` | OS 非依存 |
+| `OnNotifyShellInfo` | OS 非依存 |
+| `OnNotifyDressupInfo` | 着せ替えフック（SERIKO パーツ） |
+| `OnNotifyUserInfo` | OS 非依存 |
+| `OnNotifyOSInfo` | OS 非依存 |
+| `OnNotifyFontInfo` | OS 非依存 |
+| `OnNotifyInternationalInfo` | OS 非依存 |
+| `OnRequestValues` | OS 非依存 |
+| `OnGetValues` | OS 非依存 |
+| `OnTalkRequest` | OS 非依存 |
+| `OnHandActivate` | OS 非依存 |
+| `OnJitenBattle` | OS 非依存 |
+| `OnJitenTagBattle` | OS 非依存 |
+| `OnMglBattle` | OS 非依存 |
+| `OnKanadeTeaPartyInfomationRequest` | OS 非依存 |
+| `OnKanadeTeaParty` | OS 非依存 |
+| `OnKanadeTeaPartyEnd` | OS 非依存 |
+| `OnPoker` | OS 非依存 |
+| `OnPokerNotify` | OS 非依存 |
+| `OnMopClear` | OS 非依存 |
+| `OnNeedlePoke` | OS 非依存 |
+| `OnBeerShower` | OS 非依存 |
+| `OnDive` | OS 非依存 |
+| `OnHitThunder` | OS 非依存 |
+| `OnStampInfo` | OS 非依存 |
+| `OnStampAdd` | OS 非依存 |
+| `OnStampInfoCall` | OS 非依存 |
+| `OnPotatoReturn` | OS 非依存 |
+| `OnPotatoFileNotFound` | OS 非依存 |
+| `OnPotatoError` | OS 非依存 |
+| `OnCrystalDiskInfoEvent` | OS 非依存 |
+| `OnCrystalDiskInfoClear` | OS 非依存 |
+| `OnWeatherStation` | OS 非依存 |
+| `OnSpectrePlugin` | OS 非依存 |
+| `OnHttpcNotify` | OS 非依存 |
+| `OnKinokoObjectCreate` | OS 非依存 |
+| `OnKinokoObjectDestroy` | OS 非依存 |
+| `OnKinokoObjectChanging` | OS 非依存 |
+| `OnKinokoObjectChanged` | OS 非依存 |
+| `OnKinokoObjectInstalled` | OS 非依存 |
+| `OnSysResourceLow` | OS 非依存 |
+| `OnSysResourceCritical` | OS 非依存 |
+| `OnNekodorifObjectEmerge` | OS 非依存 |
+| `OnNekodorifObjectHit` | OS 非依存 |
+| `OnNekodorifObjectDrop` | OS 非依存 |
+| `OnNekodorifObjectVanish` | OS 非依存 |
+| `OnNekodorifObjectDodge` | OS 非依存 |
+| `OnMusicPlay` | OS 非依存 |
+| `OnFleetClockComplete` | OS 非依存 |
+| `OnElonaOmakeMMAEventNewGame` | OS 非依存 |
+| `OnElonaOmakeMMAEventGameLoad` | OS 非依存 |
+| `OnElonaOmakeMMAEventGameQuit` | OS 非依存 |
+| `OnElonaOmakeMMAEventHourPlayed` | OS 非依存 |
+| `OnElonaOmakeMMAEventMapChanged` | OS 非依存 |
+| `OnElonaOmakeMMAEventLevelUp` | OS 非依存 |
+| `OnElonaOmakeMMAEventSkillUp` | OS 非依存 |
+| `OnElonaOmakeMMAEventSkillDown` | OS 非依存 |
+| `OnElonaOmakeMMAEventBelieveGod` | OS 非依存 |
+| `OnElonaOmakeMMAEventJoinParty` | OS 非依存 |
+| `OnElonaOmakeMMAEventSleep` | OS 非依存 |
+| `OnElonaOmakeMMAEventAwake` | OS 非依存 |
+| `OnElonaOmakeMMAEventInvestNPC` | OS 非依存 |
+| `OnElonaOmakeMMAEventRandomEvent` | OS 非依存 |
+| `OnElonaOmakeMMAEventAddNewsTopic` | OS 非依存 |
+| `OnElonaOmakeMMAEventWish` | OS 非依存 |
+| `OnElonaOmakeMMAEventWished` | OS 非依存 |
+| `OnElonaOmakeMMAEventDead` | OS 非依存 |
+| `OnElonaOmakeMMAEventPetDead` | OS 非依存 |
+| `OnElonaOmakeMMAEventLastword` | OS 非依存 |
+| `OnElonaOmakeMMAEventTravelGuide` | OS 非依存 |
+| `OnElonaOmakeMMAEventAbandonPet` | OS 非依存 |
+| `OnElonaOmakeMMAEventSaleSlave` | OS 非依存 |
+| `OnElonaOmakeMMAEventSaleWife` | OS 非依存 |
+| `OnElonaOmakeMMAEventMarriage` | OS 非依存 |
+| `OnElonaOmakeMMAEventRefuseMarriage` | OS 非依存 |
+| `OnElonaOmakeMMAEventJoinGuild` | OS 非依存 |
+| `OnElonaOmakeMMAEventMutation` | OS 非依存 |
+| `OnElonaOmakeMMAEventMutationCured` | OS 非依存 |
+| `OnElonaOmakeMMAEventEtherDisease` | OS 非依存 |
+| `OnElonaOmakeMMAEventEtherDiseaseCured` | OS 非依存 |
+| `OnElonaOmakeMMAEventAdventGod` | OS 非依存 |
+| `OnElonaOmakeMMAEventMewmewmew` | OS 非依存 |
+| `OnElonaOmakeMMAEventBuyNuke` | OS 非依存 |
+| `OnElonaOmakeMMAEventSetNuke` | OS 非依存 |
+| `OnElonaOmakeMMAEventNukeExploded` | OS 非依存 |
+| `OnElonaOmakeMMAEventLomiasInTheParty` | OS 非依存 |
+| `OnElonaOmakeMMAEventLomiasKilled` | OS 非依存 |
+| `OnElonaOmakeMMAEventZeomeKilled` | OS 非依存 |
+| `OnElonaOmakeMMAEventConqueredLesimas` | OS 非依存 |
+| `OnElonaOmakeMMAEventAtonement` | OS 非依存 |
+| `OnElonaOmakeMMAEventBecomeCriminal` | OS 非依存 |
+| `OnElonaOmakeMMAEventPerformance` | OS 非依存 |
+| `OnElonaOmakeMMAEventClothOut` | OS 非依存 |
+| `OnElonaOmakeMMAEventStealItem` | OS 非依存 |
+| `OnElonaOmakeMMAEventTreasureDigging` | OS 非依存 |
+| `OnElonaOmakeMMAEventReadTreasureMap` | OS 非依存 |
+| `OnElonaOmakeMMAEventSkillLearned` | OS 非依存 |
+| `OnElonaOmakeMMAEventWeatherChanged` | OS 非依存 |
+| `OnElonaOmakeMMAEventRagnarok` | OS 非依存 |
+| `OnElonaOmakeMMAEventSisterRagnarok` | OS 非依存 |
+| `OnElonaOmakeMMAEventPray` | OS 非依存 |
+| `OnElonaOmakeMMAEventOffer` | OS 非依存 |
+| `OnElonaOmakeMMAEventPrayFailed` | OS 非依存 |
+| `OnElonaOmakeMMAEventPrayEyth` | OS 非依存 |
+| `OnElonaOmakeMMAEventAreaChanged` | OS 非依存 |
+| `OnElonaOmakeMMAEventPayTax` | OS 非依存 |
+| `OnElonaOmakeMMAEventCooking` | OS 非依存 |
+| `OnElonaOmakeMMAEventHour` | OS 非依存 |
+| `OnElonaOmakeMMAEventGrandmapocalypse` | OS 非依存 |
+| `OnMahjong` | OS 非依存 |
+| `OnMahjongResponse` | OS 非依存 |
+| `OnNostr` | OS 非依存 |
+| `OnSatolistBoot` | OS 非依存 |
+| `OnSatolistGhostOpened` | OS 非依存 |
+| `OnSatolistSaved` | OS 非依存 |
+| `OnSatolistClosed` | OS 非依存 |
+| `OnSatolistEventAdded` | OS 非依存 |
+| `OnSatolistDictionaryFolderChanged` | OS 非依存 |
+| `OnTourabuConquestStart` | OS 非依存 |
+| `OnTourabuConquestEnd` | OS 非依存 |
+| `OnTourabuDutyStart` | OS 非依存 |
+| `OnTourabuDutyEnd` | OS 非依存 |
+| `OnElinAllyCondition` | OS 非依存 |
+| `OnElinAllyDead` | OS 非依存 |
+| `OnElinCatchFish` | OS 非依存 |
+| `OnElinMapCharaGenerate` | OS 非依存 |
+| `OnElinMapEnter` | OS 非依存 |
+| `OnElinMapItemGenerate` | OS 非依存 |
+| `OnElinPCCondition` | OS 非依存 |
+| `OnElinPCDead` | OS 非依存 |
+| `OnElinTarget` | OS 非依存 |
+| `OnApplicationBoot` | OS 非依存 |
+| `OnApplicationClose` | OS 非依存 |
+| `OnApplicationExist` | OS 非依存 |
+| `OnApplicationVersion` | OS 非依存 |
+| `OnApplicationOperationFinish` | OS 非依存 |
+| `OnApplicationFileOpen` | OS 非依存 |
+| `OnWebsiteUpdateNotify` | OS 非依存 |
+| `OnUkadocScriptExample` | OS 非依存 |
+
 
 ---
 
-## 翻訳ノート
+# Appendix: Ourin(mac) 差分注記（イベント, 2025-07-29 21:06 UTC+09:00）
 
-このドキュメントは英語原本の日本語翻訳用プレースホルダーです。
+Ourin における **OS 依存イベント**のマッピング／制約を明文化します。本文の ID/意味は Ukadoc に準拠し、ここでは **発火源と公開API**を明記します。
 
-英語版が正式な仕様を含んでいます。この日本語版は以下を維持しながら翻訳すべきです：
+## 電源/スリープ/画面
+| イベント例 | Ourin(mac) 発火源/メモ |
+|---|---|
+| `OnSysSuspend` / `OnSysResume` | **NSWorkspace.willSleepNotification / didWakeNotification** をブリッジ。 |
+| `OnScreenSaverStart` / `OnScreenSaverEnd` | 画面スリープ/復帰は **screensDidSleepNotification / screensDidWakeNotification** を準用。 |
+| `OnDisplay*` | 画面構成変化は NSWorkspace 通知や CGDisplay 変更の観測で補完（必要最小限）。 |
 
-- 技術的正確性
-- 他の日本語ドキュメントとの用語の一貫性
-- 元の構造とフォーマット
-- すべてのコード例は変更なし
-- コメントと説明部分の適切な翻訳
+## バッテリー/電源
+| イベント例 | Ourin(mac) 発火源/メモ |
+|---|---|
+| `OnBattery*`（残量/充電/AC接続など） | **IOKit IOPowerSources**（`IOPSCopyPowerSourcesInfo` 系）をポーリング/通知で監視。 |
 
----
+## 通知/トレイ相当
+| イベント例 | Ourin(mac) 発火源/メモ |
+|---|---|
+| `OnTrayBalloon*` 系 | **NSStatusItem** 常駐＋ **UNUserNotificationCenter** で代替。タイムアウト等は **OS 依存**。 |
 
-## 内容
+## ファイル/ゴミ箱（Recycle Bin 相当）
+| イベント例 | Ourin(mac) 発火源/メモ |
+|---|---|
+| `OnRecycleBin*` | `~/.Trash` 配下を **FSEvents** で監視（Best‑Effort）。APFS/権限により検出粒度は変動。 |
 
-*(英語原本から翻訳予定)*
+## 外観/テーマ
+| イベント例 | Ourin(mac) 発火源/メモ |
+|---|---|
+| `OnDarkTheme`（相当の独自拡張を含む） | **NSApplication.effectiveAppearance** を監視（KVO 等）。 |
 
----
+## 非推奨/縮退候補（mac に概念差あり）
+| イベント例 | Ourin(mac) 方針 |
+|---|---|
+| `OnTabletMode` | macOS にタブレットモード概念なし。**非対応**（常に未発火）。 |
+| `OnVirtualDesktopChanged` 等 | **Spaces** は**安定した公開 API が乏しい**ため、既定は未対応。必要なら実験的に通知のみに留める。 |
 
-**翻訳ステータス:** ⏳ 待機中  
-**翻訳者:** 未定  
-**レビュー:** 未定  
-**最終更新日:** 2025-10-23
+#### 参考（出典）
+- Ukadoc: **SHIORI Event リスト（本体／外部）**。  
+- Apple: **NSWorkspace** の各通知（sleep/wake/screens）、**IOKit IOPowerSources**（バッテリー/AC 判定）、**File System Events (FSEvents)**、**UNUserNotificationCenter**、**NSStatusItem**、**effectiveAppearance**。

--- a/docs/SHIORI_RESOURCE_3.0M_SPEC_ja-jp.md
+++ b/docs/SHIORI_RESOURCE_3.0M_SPEC_ja-jp.md
@@ -1,32 +1,167 @@
 # SHIORI Resource — **3.0M‑Mac 仕様書（完全版 / UKADOC準拠）**
+**ステータス:** Draft / Ourin (macOS 10.15+ / Universal 2)  
+**更新日:** 2026-06-15 (JST) — 原本 [SHIORI_RESOURCE_3.0M_SPEC_en-us.md](./SHIORI_RESOURCE_3.0M_SPEC_en-us.md) から日本語版を整備  
+**互換方針:** UKADOC「[SHIORI Resourceリスト]」に載る**全要素**の**名称・意味・返値**を踏襲し、**OS 依存値のみ macOS ネイティブ（M‑Diff）**に置換。  
+**対象:** Ourin（ベースウェア）および SHIORI 実装者。
 
-**ステータス:** 翻訳待ち  
-**原本:** [SHIORI_RESOURCE_3.0M_SPEC_en-us.md](./SHIORI_RESOURCE_3.0M_SPEC_en-us.md)  
-**言語:** 日本語
-
----
-
-## 翻訳ノート
-
-このドキュメントは英語原本の日本語翻訳用プレースホルダーです。
-
-英語版が正式な仕様を含んでいます。この日本語版は以下を維持しながら翻訳すべきです：
-
-- 技術的正確性
-- 他の日本語ドキュメントとの用語の一貫性
-- 元の構造とフォーマット
-- すべてのコード例は変更なし
-- コメントと説明部分の適切な翻訳
+> 典拠: SHIORI Resource の一次情報は UKADOC を参照。項目名や返値の意味は UKADOC が正です。  
+> 本仕様は **macOS 移植差分（M‑Diff）**と**実装上の統一方針**を追加定義します。
 
 ---
 
-## 内容
-
-*(英語原本から翻訳予定)*
+## 目次
+- [1. 基本規約](#1-基本規約)
+- [2. M‑Diff（macOS 置換点）](#2-m-diffmacos-置換点)
+- [3. 要素一覧（完全）](#3-要素一覧完全)
+  - [3.1 SHIORI情報](#31-shiori情報)
+  - [3.2 ゴースト情報](#32-ゴースト情報)
+  - [3.3 更新情報](#33-更新情報)
+  - [3.4 オーナードローメニュー画像](#34-オーナードローメニュー画像)
+  - [3.5 オーナードローメニュー文字色](#35-オーナードローメニュー文字色)
+  - [3.6 オーナードローメニュー項目名（caption 系）](#36-オーナードローメニュー項目名caption-系)
+  - [3.7 ツールチップイベント（補足）](#37-ツールチップイベント補足)
+- [4. 返答規則と既定値](#4-返答規則と既定値)
+- [5. 互換性と注意点](#5-互換性と注意点)
+- [6. 変更履歴](#6-変更履歴)
 
 ---
 
-**翻訳ステータス:** ⏳ 待機中  
-**翻訳者:** 未定  
-**レビュー:** 未定  
-**最終更新日:** 2025-10-23
+## 1. 基本規約
+- **文字コード:** 既定 **UTF‑8**。互換のため **CP932/Shift_JIS** 受理→内部 UTF‑8 正規化可。  
+- **改行:** CR+LF を**受理**（内部処理は LF 正規化可）。  
+- **返値の型:** 文字列／数値／ブール（`0/1` 文字列）／色（R,G,B の整数）など。戻りは**さくらスクリプトでない短文**が基本。  
+- **省略時:** 未対応・未設定は空文字を返す。`*.visible` は省略時 1（表示）。
+
+## 2. M‑Diff（macOS 置換点）
+- **パス（`*.filename` / `log_path` / 各URL・画像パス）:** **POSIX 絶対パス**または **`file://` URL** を標準。Windows 形式が来た場合は受信側で正規化。  
+- **座標（`*.defaultleft` / `*.defaulttop` / 入力ボックス `.default*`）:** **ディスプレイ座標（ピクセル）**。Ourin 内部では Cocoa の座標系差（原点位置）の吸収を行い、SSP と等価の表示位置になるよう変換。  
+- **色:** `menu.*.color.(r|g|b)` は **0–255 の整数**を推奨。  
+- **列挙:** `popupmenu.type` 等の列挙値は **SSP と同義**。未知値は既定動作にフォールバック。
+
+---
+
+## 3. 要素一覧（完全）
+
+### 3.1 SHIORI情報
+| Key | 意味（要約） | 返値の型 | 備考 |
+|---|---|---|---|
+| `version` | SHIORI のバージョン情報（*プロトコル版ではない*） | 文字列 | 自動返却。 |
+| `craftman` | SHIORI 作者名（7bit） | 文字列 | 自動返却。 |
+| `craftmanw` | SHIORI 作者名（拡張文字可） | 文字列 | 自動返却。 |
+| `name` | SHIORI 名称（ゴースト名ではない、7bit） | 文字列 | 自動返却。 |
+| `log_path` | SHIORI ログファイルのフルパス | パス文字列 | Ourin は POSIX/`file://` を受理・推奨。 |
+
+### 3.2 ゴースト情報
+| Key | 意味（要約） | 返値の型 | 備考 |
+|---|---|---|---|
+| `homeurl` | ネットワーク更新用 URL / 位置 | URL/文字列 | `descript.txt` と併記時の優先は原典参照。 |
+| `useorigin1` | 更新ファイルカウントの開始数（1:1開始/0:0開始） | `0/1` | 互換値。 |
+| `username` | ユーザー表示名 | 文字列 |  |
+
+**デフォルト位置（画像/画面）**  
+| Key | 意味 | 返値 | 備考 |
+|---|---|---|---|
+| `sakura.defaultx` / `kero.defaultx` / `char*.defaultx` | 画像ベースX | 数値 |  |
+| `sakura.defaulty` / `kero.defaulty` / `char*.defaulty` | 画像ベースY | 数値 |  |
+| `sakura.defaultleft` / `kero.defaultleft` / `char*.defaultleft` | 画面X | 数値 | M‑Diff: Cocoa 座標を吸収。 |
+| `sakura.defaulttop` / `kero.defaulttop` / `char*.defaulttop` | 画面Y | 数値 | 同上。 |
+
+**入力ボックス初期位置**  
+`(communicatebox|scriptbox|addressbar|teachbox|dateinput|timeinput|ipinput|sliderinput|passwordinput|inputbox).defaultleft` / `.defaulttop` … ディスプレイ座標（ピクセル）。
+
+**おすすめ/ポータル**  
+| Key | 意味 | 返値 | 形式 |
+|---|---|---|---|
+| `sakura.recommendsites` / `kero.recommendsites` / `char*.recommendsites` | おすすめリスト | 連結文字列 | `項目名`[0x01]`url`[0x01]`バナー画像パス`[0x01]`選択時トーク` [0x02] … |
+| `sakura.portalsites` | ポータルリスト | 連結文字列 | 同上。 |
+| `sakura.recommendbuttoncaption` / `kero.*` / `char*.recommendbuttoncaption` | ボタン名 | 文字列 |  |
+| `updatebuttoncaption` / `vanishbuttoncaption` / `readmebuttoncaption` | ボタン名 | 文字列 |  |
+| `vanishbuttonvisible` | 消滅通告ボタン表示 | `0/1` | 省略時 1。 |
+| `sakura.popupmenu.visible` / `kero.*` / `char*.popupmenu.visible` | オーナードローメニュー表示 | `0/1` | |
+| `sakura.popupmenu.type` / `kero.*` / `char*.popupmenu.type` | メニュー種別 | 列挙 | SSP 同義。 |
+| `getaistate` | AI 状態 | 文字列 |  |
+| `getaistateex` | AI 状態（複数） | 連結文字列 | 0x01 区切りなど。 |
+| `legacyinterface` | 互換用フラグ | `0/1` | SSP 互換。 |
+
+### 3.3 更新情報
+| Key | 意味 | 返値 | 備考 |
+|---|---|---|---|
+| `other_homeurl_override` | 他 source の homeurl 上書き | 文字列 | 既定空。 |
+
+### 3.4 オーナードローメニュー画像
+| Key | 意味 | 返値 | 備考 |
+|---|---|---|---|
+| `menu.sidebar.bitmap.filename` | サイドバー画像 | パス文字列 | M‑Diff: POSIX/`file://`。 |
+| `menu.background.bitmap.filename` | 背景画像 | パス文字列 | 同上。 |
+| `menu.foreground.bitmap.filename` | 前景画像 | パス文字列 | 同上。 |
+
+### 3.5 オーナードローメニュー文字色
+| Key | 意味 | 返値 |
+|---|---|---|
+| `menu.background.font.color.r/g/b` | 背景用フォント色（RGB） | 整数(0–255) |
+| `menu.foreground.font.color.r/g/b` | 前景用フォント色（RGB） | 整数(0–255) |
+| `menu.separator.color.r/g/b` | セパレータ線色（RGB） | 整数(0–255) |
+| `menu.frame.color.r/g/b` | フレーム線色（RGB） | 整数(0–255) |
+| `menu.disable.font.color.r/g/b` | 無効項目フォント色（RGB） | 整数(0–255) |
+
+### 3.6 オーナードローメニュー項目名（caption 系）
+以下の **`.caption`** キーはメニューに表示するラベル。**Ourin では `X.caption` に対し `X.visible`（`0/1`）も受理**し、未指定は 1（表示）とする。
+
+```
+activaterootbutton.caption, addressbarbutton.caption, alignrootbutton.caption,
+alwaysstayontopbutton.caption, alwaystrayiconvisiblebutton.caption,
+balloonhistorybutton.caption, balloonrootbutton.caption, biffallbutton.caption,
+biffbutton.caption, calendarbutton.caption, callghosthistorybutton.caption,
+callghostrootbutton.caption, callsstpsendboxbutton.caption, char*.recommendsites.caption,
+charsetbutton.caption, closeballoonbutton.caption, closebutton.caption,
+collisionvisiblebutton.caption, configurationbutton.caption, configurationrootbutton.caption,
+debugballoonbutton.caption, definedsurfaceonlybutton.caption, dressuprootbutton.caption,
+duibutton.caption, enableballoonmovebutton.caption, firststaffbutton.caption,
+ghostexplorerbutton.caption, ghosthistorybutton.caption, ghostinstallbutton.caption,
+ghostrootbutton.caption, headlinesensehistorybutton.caption, headlinesenserootbutton.caption,
+helpbutton.caption, hidebutton.caption, historyrootbutton.caption, inforootbutton.caption,
+leavepassivebutton.caption, messengerbutton.caption, pluginhistorybutton.caption,
+pluginrootbutton.caption, portalrootbutton.caption, purgeghostcachebutton.caption,
+quitbutton.caption, rateofuseballoonbutton.caption, rateofusebutton.caption,
+rateofuserootbutton.caption, rateofusetotalbutton.caption, readmebutton.caption,
+recommendrootbutton.caption, regionenabledbutton.caption, reloadinfobutton.caption,
+resetballoonpositionbutton.caption, resettodefaultbutton.caption, scriptlogbutton.caption,
+shellrootbutton.caption, shellscaleotherbutton.caption, shellscalerootbutton.caption,
+sntpbutton.caption, switchactivatewhentalkbutton.caption,
+switchactivatewhentalkexceptupdatebutton.caption, switchautobiffbutton.caption,
+switchautoheadlinesensebutton.caption, switchblacklistingbutton.caption,
+switchcompatiblemodebutton.caption, switchconsolealwaysvisiblebutton.caption,
+switchconsolevisiblebutton.caption, switchdeactivatebutton.caption,
+switchdontactivatebutton.caption, switchdontforcealignbutton.caption,
+switchduivisiblebutton.caption, switchforcealignfreebutton.caption,
+switchforcealignlimitbutton.caption, switchignoreserikomovebutton.caption,
+switchlocalsstpbutton.caption, switchmovetodefaultpositionbutton.caption,
+switchproxybutton.caption, switchquietbutton.caption, switchreloadbutton.caption,
+switchreloadtempghostbutton.caption, switchremotesstpbutton.caption, switchrootbutton.caption,
+switchtalkghostbutton.caption, systeminfobutton.caption, updatebutton.caption,
+updatefmobutton.caption, updateplatformbutton.caption, utilityrootbutton.caption,
+vanishbutton.caption, aistatebutton.caption, dictationbutton.caption, texttospeechbutton.caption
+```
+
+**ショートカットキー**  
+項目のショートカットキーは UKADOC の「ショートカットキー」節の規定に従う（キー設定で当該項目を起動）。
+
+### 3.7 ツールチップイベント（補足）
+`tooltip` / `balloon_tooltip` は **ツールチップ表示時に参照されるイベント名**。Ourin は UKADOC の推奨順に解決し、スクリプトを取得して表示する。
+
+---
+
+## 4. 返答規則と既定値
+- 返答は**短いテキスト**（`0/1` や連結文字列含む）。  
+- `*.visible` は省略時 1。  
+- おすすめ/ポータルの**連結形式**は `[0x01]`（SOH）と `[0x02]`（STX）で区切る慣例に従う。
+
+## 5. 互換性と注意点
+- **SHIORI/3.0 準拠**：Resource は SHIORI/3.0 の**通常イベント扱い**だが、返値がスクリプトではない点に注意。  
+- **未知キー**：Ourin は未知の Resource でも透過で処理可能（将来拡張互換）。  
+- **画像パス**：`menu.*.bitmap.filename` の相対は**ゴーストルート**基準で解決。  
+- **キャッシュ/SET**：Ourin の `ResourceBridge` は 5 秒 TTL でキャッシュし、`set(key:value:)` による SET 上書き層を持つ（上書き値は SHIORI 問い合わせより優先、空文字で定義削除）。
+
+## 6. 変更履歴
+- 2025‑07‑27: 初版（3.0M‑Mac、全要素）。
+- 2026‑06‑15: 日本語版を原本（en-us）から整備。ResourceBridge のキャッシュ/SET 追記。

--- a/docs/SPEC_PLUGIN_2.0M_ja-jp.md
+++ b/docs/SPEC_PLUGIN_2.0M_ja-jp.md
@@ -131,7 +131,7 @@ Charset: UTF-8
 - [x] **文字コード対応**: UTF-8 既定、Shift_JIS/CP932 の自動検出を実装済み
 - [x] **PLUGIN/2.0M プロトコル**: `PluginProtocol.swift` にて完全実装済み
 - [x] **イベントディスパッチ**: `PluginRegistry.swift` にて PLUGIN/2.0M 互換のイベントディスパッチを実装済み
-- [ ] **XPC 隔離**: 未実装（現在は同一プロセス内で実行）
+- [x] **XPC 隔離**: 実装済み (2026-06-15)。`PluginXpcBackend.swift`(`OurinPluginXPC`/`PluginXpcClient`) を新設し、`OURIN_PLUGIN_ISOLATION_MODE=xpc` または `OURIN_PLUGIN_XPC_SERVICE` 指定時に `PluginEventDispatcher` が別プロセスのワーカーへ透過転送する（既定はインプロセス）。
 
 ### 12.2 実装済みの機能
 
@@ -180,9 +180,7 @@ Charset: UTF-8
 
 ### 12.3 未実装の機能
 
-1. **XPC プロセス分離**
-   - プラグインの別プロセス実行
-   - セキュリティサンドボックス分離
+1. ~~**XPC プロセス分離**~~ → 実装済み (2026-06-15)。`PluginXpcClient` 経由で別プロセスワーカーへ透過転送（env で有効化）。
 
 2. **追加のイベントタイプ**
    - 全ての PLUGIN/2.0 イベントタイプの実装（基本的なイベントは実装済み、追加イベントは必要に応じて実装可能）


### PR DESCRIPTION
…-M5)

Address all open items from docs/CODE_SPEC_DIFF_2026-06.md across SSTP, SHIORI, Plugin, Property, Balloon, NAR and ghost-display subsystems.

Tier 1 (C/A/B):
- SERIKO cursor 4-branch keys (mouseup/down/hover/wheellist) in GhostPropertyProvider, GET/SET.
- Unify HTTP+raw SSTP on port 9801 via UnifiedSstpListener (drop 9810).
- Unify XPC on OurinSSTPXPC.executeSSTP (retire OurinExternalSstpXPC).

P1-P4:
- Property generic names: thumbnail/update_result/update_time/shiori.<var>/ index, plus (sakura|kero|char*).bind.menu GET/SET.
- dylib `loadu` (UTF-8 path) fallbacks across SAORI/SHIORI/Headline/Plugin.
- Plugin XPC/process isolation (PluginXpcBackend, env-gated).
- SHIORI internal-event SecurityLevel injection (ShioriSecurityContext); also pass headers to the non-YAYA BridgeToSHIORI path.

R1-R5:
- NAR update apply wiring (download -> install / incremental file write).
- ResourceBridge SET override layer + thread safety.
- Balloon PNA alpha in generic ImageLoader; true 8-direction outline stroke.
- Forward OnChoiceSelect(Ex)/OnAnchorSelect(Ex) to plugins.
- Lazy/unbounded character window creation (ensureCharacterWindow).

M1-M5:
- Multiple concurrent ghosts foundation (AppDelegate.additionalGhosts, launchAdditionalGhost, FMO aggregation; \+ boots in-process).
- Retina @2x/@3x image variants (RetinaImageLoader).
- Wire showChoiceDialog on playback completion so \q/\__q work + plugin forward.
- Resolve ja-jp translation stubs for the user-facing specs.
- Serialize ExternalServerTests with per-test singleton reset (fix parallel flakiness).

Docs synced (CODE_SPEC_DIFF, TODO/todo.md deprecation, SERIKO/PLUGIN/SHIORI spec "未実装" corrections). Build + serial/parallel tests pass.